### PR TITLE
Fix duplicate clients, add tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  backend-tests:
+    name: Backend Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: api
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: maven
+
+      - name: Run tests
+        run: ./mvnw test -Dtest="com.nail_art.appointment_book.services.*" -q
+
+  frontend-lint:
+    name: Frontend Lint & Typecheck
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: client
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: client/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npx tsc -b --noEmit
+
+      - name: Lint
+        run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           cache: maven
 
       - name: Run tests
-        run: ./mvnw test -Dtest="com.nail_art.appointment_book.services.*" -q
+        run: ./mvnw test -Dtest="com.nail_art.appointment_book.services.**" -q
 
   frontend-lint:
     name: Frontend Lint & Typecheck

--- a/api/src/main/java/com/nail_art/appointment_book/configs/MongoConfig.java
+++ b/api/src/main/java/com/nail_art/appointment_book/configs/MongoConfig.java
@@ -1,14 +1,36 @@
 package com.nail_art.appointment_book.configs;
 
 import com.mongodb.client.MongoClient;
+import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
+import org.bson.Document;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.Index;
+import org.springframework.data.mongodb.core.index.PartialIndexFilter;
 
 @Configuration
 public class MongoConfig {
     @Autowired
     private MongoClient mongoClient;
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    @PostConstruct
+    public void ensureIndexes() {
+        mongoTemplate.indexOps("Clients").ensureIndex(
+                new Index()
+                        .on("phoneNumber", Sort.Direction.ASC)
+                        .unique()
+                        .named("phoneNumber_unique_partial")
+                        .partial(PartialIndexFilter.of(
+                                Document.parse("{ phoneNumber: { $type: 'string', $gt: '' } }")
+                        ))
+        );
+    }
 
     @PreDestroy
     public void closeMongoClient() {

--- a/api/src/main/java/com/nail_art/appointment_book/entities/Client.java
+++ b/api/src/main/java/com/nail_art/appointment_book/entities/Client.java
@@ -6,8 +6,6 @@ import lombok.Data;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import java.util.List;
-
 @Data
 @Document(collection = "Clients")
 public class Client {
@@ -21,8 +19,6 @@ public class Client {
 
     @Pattern(regexp = "^((\\+\\d{1,2}\\s?)?\\(?\\d{3}\\)?[\\s.-]?\\d{3}[\\s.-]?\\d{4})?$", message = "Not a valid phone number")
     private String phoneNumber;
-
-    private List<Long> appointmentIds;
 
     public Long getId() {
         return id;
@@ -48,11 +44,4 @@ public class Client {
         this.phoneNumber = phoneNumber;
     }
 
-    public List<Long> getAppointmentIds() {
-        return appointmentIds;
-    }
-
-    public void setAppointmentIds(List<Long> appointmentIds) {
-        this.appointmentIds = appointmentIds;
-    }
 }

--- a/api/src/main/java/com/nail_art/appointment_book/exceptions/GlobalExceptionHandler.java
+++ b/api/src/main/java/com/nail_art/appointment_book/exceptions/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.security.SignatureException;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ProblemDetail;
 import org.springframework.security.access.AccessDeniedException;
@@ -46,6 +47,11 @@ public class GlobalExceptionHandler {
         if (exception instanceof ExpiredJwtException) {
             errorDetail = ProblemDetail.forStatusAndDetail(HttpStatusCode.valueOf(403), exception.getMessage());
             errorDetail.setProperty("description", "The JWT token has expired");
+        }
+
+        if (exception instanceof DuplicateKeyException) {
+            errorDetail = ProblemDetail.forStatusAndDetail(HttpStatusCode.valueOf(409), exception.getMessage());
+            errorDetail.setProperty("description", "A client with this phone number already exists");
         }
 
         if (errorDetail == null) {

--- a/api/src/main/java/com/nail_art/appointment_book/services/AppointmentService.java
+++ b/api/src/main/java/com/nail_art/appointment_book/services/AppointmentService.java
@@ -68,26 +68,13 @@ public class AppointmentService {
                 Client client = new Client();
                 client.setName(appointment.getName());
                 client.setPhoneNumber(appointment.getPhoneNumber());
-                client.setAppointmentIds(List.of(id));
-                long clientId = counterService.getNextSequence("Appointments");
+                long clientId = counterService.getNextSequence("Clients");
                 client.setId(clientId);
                 appointment.setClientId(clientId);
                 clientRepository.save(client);
             } else {
-                List<Long> appointments = tempClient.getAppointmentIds();
-                appointments.add(appointment.getId());
-                tempClient.setAppointmentIds(appointments);
                 appointment.setClientId(tempClient.getId());
                 appointment.setName(tempClient.getName());
-                clientRepository.save(tempClient);
-            }
-        } else if (appointment.getClientId() != null) {
-            Client tempClient = clientRepository.findById(appointment.getClientId()).orElse(null);
-            if (tempClient != null) {
-                List<Long> appointments = tempClient.getAppointmentIds();
-                appointments.add(appointment.getId());
-                tempClient.setAppointmentIds(appointments);
-                clientRepository.save(tempClient);
             }
         }
         return appointmentRepository.save(appointment);
@@ -118,8 +105,15 @@ public class AppointmentService {
             tempAppointment.get().setPhoneNumber(appointment.getPhoneNumber());
             tempAppointment.get().setShowedUp(appointment.getShowedUp());
 
-            // update client when editing appointment if client exists
+            // link client if appointment has a phone number but no clientId
             Long clientId = appointment.getClientId();
+            if (clientId == null && appointment.getPhoneNumber() != null && !appointment.getPhoneNumber().isEmpty()) {
+                Client matchedClient = clientRepository.findByPhoneNumber(appointment.getPhoneNumber()).orElse(null);
+                if (matchedClient != null) {
+                    clientId = matchedClient.getId();
+                    tempAppointment.get().setClientId(clientId);
+                }
+            }
             if (clientId == null) {
                 return Optional.of(appointmentRepository.save(tempAppointment.get()));
             }
@@ -165,16 +159,6 @@ public class AppointmentService {
         Optional<Appointment> tempAppointment = getAppointmentById(appointment.getId());
         if (tempAppointment.isPresent()) {
             appointmentRepository.delete(tempAppointment.get());
-            Long clientId = appointment.getClientId();
-            if (clientId != null) {
-                Client tempClient = clientRepository.findById(clientId).orElse(null);
-                if (tempClient != null) {
-                    List<Long> appointments = tempClient.getAppointmentIds();
-                    appointments.remove(appointment.getId());
-                    tempClient.setAppointmentIds(appointments);
-                    clientRepository.save(tempClient);
-                }
-            }
             return true;
         }
         return false;

--- a/api/src/main/java/com/nail_art/appointment_book/services/AppointmentService.java
+++ b/api/src/main/java/com/nail_art/appointment_book/services/AppointmentService.java
@@ -117,7 +117,7 @@ public class AppointmentService {
             if (clientId == null) {
                 return Optional.of(appointmentRepository.save(tempAppointment.get()));
             }
-            Client client = clientRepository.findById(appointment.getClientId()).orElse(null);
+            Client client = clientRepository.findById(clientId).orElse(null);
             if (client != null) {
                 client.setName(appointment.getName());
                 client.setPhoneNumber(appointment.getPhoneNumber());

--- a/api/src/main/java/com/nail_art/appointment_book/services/ClientService.java
+++ b/api/src/main/java/com/nail_art/appointment_book/services/ClientService.java
@@ -43,29 +43,14 @@ public class ClientService {
     }
 
     public Client createClient(Client client) {
+        if (client.getPhoneNumber() != null && !client.getPhoneNumber().isEmpty()) {
+            clientRepository.findByPhoneNumber(client.getPhoneNumber()).ifPresent(existing -> {
+                throw new IllegalArgumentException("A client with phone number " + client.getPhoneNumber() + " already exists");
+            });
+        }
         long id = counterService.getNextSequence("Clients");
         client.setId(id);
         return clientRepository.save(client);
-    }
-
-    public void deleteAppointmentFromClient(long clientId, long appointmentId) {
-        Client tempClient = clientRepository.findById(clientId).orElse(null);
-        if (tempClient != null) {
-            List<Long> appointments = tempClient.getAppointmentIds();
-            appointments.remove(appointmentId);
-            tempClient.setAppointmentIds(appointments);
-            clientRepository.save(tempClient);
-        }
-    }
-
-    public void addAppointmentToClient(long clientId, long appointmentId) {
-        Client tempClient = clientRepository.findById(clientId).orElse(null);
-        if (tempClient != null) {
-            List<Long> appointments = tempClient.getAppointmentIds();
-            appointments.add(appointmentId);
-            tempClient.setAppointmentIds(appointments);
-            clientRepository.save(tempClient);
-        }
     }
 
     public Optional<Client> editClient(Client client) {
@@ -73,7 +58,6 @@ public class ClientService {
         if (tempClient != null) {
             tempClient.setName(client.getName());
             tempClient.setPhoneNumber(client.getPhoneNumber());
-            tempClient.setAppointmentIds(client.getAppointmentIds());
             List<Appointment> tempAppointments = appointmentRepository.findByClientId(tempClient.getId());
             for (Appointment appointment : tempAppointments) {
                 appointment.setName(client.getName());

--- a/api/src/test/java/com/nail_art/appointment_book/services/AppointmentServiceTest.java
+++ b/api/src/test/java/com/nail_art/appointment_book/services/AppointmentServiceTest.java
@@ -1,0 +1,300 @@
+package com.nail_art.appointment_book.services;
+
+import com.nail_art.appointment_book.entities.Appointment;
+import com.nail_art.appointment_book.entities.Client;
+import com.nail_art.appointment_book.repositories.AppointmentRepository;
+import com.nail_art.appointment_book.repositories.ClientRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AppointmentServiceTest {
+
+    @Mock
+    private AppointmentRepository appointmentRepository;
+
+    @Mock
+    private CounterService counterService;
+
+    @Mock
+    private ClientRepository clientRepository;
+
+    @InjectMocks
+    private AppointmentService appointmentService;
+
+    private Appointment makeAppointment(String name, String phone, String date, String start, String end) {
+        Appointment appt = new Appointment();
+        appt.setName(name);
+        appt.setPhoneNumber(phone);
+        appt.setDate(date);
+        appt.setStartTime(start);
+        appt.setEndTime(end);
+        appt.setEmployeeId(1);
+        appt.setServices(List.of(1));
+        appt.setReminderSent(false);
+        appt.setShowedUp(false);
+        return appt;
+    }
+
+    @Nested
+    class CreateAppointment {
+
+        @Test
+        void createsNewClientWhenPhoneProvidedAndNoClientExists() {
+            Appointment appt = makeAppointment("Jane Doe", "330-555-1234", "2026-04-10", "T10:00", "T11:00");
+            when(counterService.getNextSequence("Appointments")).thenReturn(100L);
+            when(counterService.getNextSequence("Clients")).thenReturn(50L);
+            when(clientRepository.findByPhoneNumber("330-555-1234")).thenReturn(Optional.empty());
+            when(appointmentRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            Appointment result = appointmentService.createAppointment(appt);
+
+            assertEquals(50L, result.getClientId());
+            ArgumentCaptor<Client> clientCaptor = ArgumentCaptor.forClass(Client.class);
+            verify(clientRepository).save(clientCaptor.capture());
+            Client savedClient = clientCaptor.getValue();
+            assertEquals("Jane Doe", savedClient.getName());
+            assertEquals("330-555-1234", savedClient.getPhoneNumber());
+            assertEquals(50L, savedClient.getId());
+        }
+
+        @Test
+        void linksExistingClientWhenPhoneMatches() {
+            Appointment appt = makeAppointment("Jane", "330-555-1234", "2026-04-10", "T10:00", "T11:00");
+            Client existing = new Client();
+            existing.setId(25L);
+            existing.setName("Jane Doe");
+            existing.setPhoneNumber("330-555-1234");
+
+            when(counterService.getNextSequence("Appointments")).thenReturn(100L);
+            when(clientRepository.findByPhoneNumber("330-555-1234")).thenReturn(Optional.of(existing));
+            when(appointmentRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            Appointment result = appointmentService.createAppointment(appt);
+
+            assertEquals(25L, result.getClientId());
+            assertEquals("Jane Doe", result.getName());
+            verify(clientRepository, never()).save(any());
+        }
+
+        @Test
+        void skipsClientLinkingWhenPhoneIsEmpty() {
+            Appointment appt = makeAppointment("Walk-in", "", "2026-04-10", "T10:00", "T11:00");
+            when(counterService.getNextSequence("Appointments")).thenReturn(100L);
+            when(appointmentRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            Appointment result = appointmentService.createAppointment(appt);
+
+            assertNull(result.getClientId());
+            verify(clientRepository, never()).findByPhoneNumber(any());
+        }
+
+        @Test
+        void setsIdAndReminderSent() {
+            Appointment appt = makeAppointment("Test", "", "2026-04-10", "T10:00", "T11:00");
+            when(counterService.getNextSequence("Appointments")).thenReturn(42L);
+            when(appointmentRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            Appointment result = appointmentService.createAppointment(appt);
+
+            assertEquals(42L, result.getId());
+            assertFalse(result.getReminderSent());
+        }
+
+        @Test
+        void throwsWhenEndTimeBeforeStartTime() {
+            Appointment appt = makeAppointment("Test", "", "2026-04-10", "T14:00", "T10:00");
+
+            assertThrows(IllegalArgumentException.class, () ->
+                    appointmentService.createAppointment(appt));
+        }
+
+        @Test
+        void throwsWhenEndTimeEqualsStartTime() {
+            Appointment appt = makeAppointment("Test", "", "2026-04-10", "T10:00", "T10:00");
+
+            assertThrows(IllegalArgumentException.class, () ->
+                    appointmentService.createAppointment(appt));
+        }
+
+        @Test
+        void normalizesUnpaddedTimes() {
+            Appointment appt = makeAppointment("Test", "", "2026-04-10", "T9:00", "T10:00");
+            when(counterService.getNextSequence("Appointments")).thenReturn(1L);
+            when(appointmentRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            Appointment result = appointmentService.createAppointment(appt);
+
+            assertEquals("T09:00", result.getStartTime());
+            assertEquals("T10:00", result.getEndTime());
+        }
+
+        @Test
+        void throwsOnNullTime() {
+            Appointment appt = makeAppointment("Test", "", "2026-04-10", null, "T10:00");
+
+            assertThrows(IllegalArgumentException.class, () ->
+                    appointmentService.createAppointment(appt));
+        }
+
+        @Test
+        void usesClientsCounterNotAppointmentsForNewClient() {
+            Appointment appt = makeAppointment("New Person", "555-123-4567", "2026-04-10", "T10:00", "T11:00");
+            when(counterService.getNextSequence("Appointments")).thenReturn(100L);
+            when(counterService.getNextSequence("Clients")).thenReturn(50L);
+            when(clientRepository.findByPhoneNumber("555-123-4567")).thenReturn(Optional.empty());
+            when(appointmentRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            appointmentService.createAppointment(appt);
+
+            // Called once for "Appointments" (appt id) and once for "Clients" (client id)
+            verify(counterService).getNextSequence("Appointments");
+            verify(counterService).getNextSequence("Clients");
+            verify(counterService, times(2)).getNextSequence(anyString());
+        }
+    }
+
+    @Nested
+    class EditAppointment {
+
+        @Test
+        void linksClientWhenPhoneAddedToClientlessAppointment() {
+            Appointment existing = makeAppointment("Test", "", "2026-04-10", "T10:00", "T11:00");
+            existing.setId(1);
+            existing.setReminderSent(false);
+
+            Appointment edited = makeAppointment("Test", "330-555-9999", "2026-04-10", "T10:00", "T11:00");
+            edited.setId(1);
+            edited.setClientId(null);
+            edited.setReminderSent(false);
+
+            Client client = new Client();
+            client.setId(25L);
+            client.setName("Test");
+            client.setPhoneNumber("330-555-9999");
+
+            when(appointmentRepository.findById(1L)).thenReturn(Optional.of(existing));
+            when(clientRepository.findByPhoneNumber("330-555-9999")).thenReturn(Optional.of(client));
+            when(appointmentRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            Optional<Appointment> result = appointmentService.editAppointment(edited);
+
+            assertTrue(result.isPresent());
+            assertEquals(25L, result.get().getClientId());
+        }
+
+        @Test
+        void doesNotLinkClientWhenPhoneIsEmpty() {
+            Appointment existing = makeAppointment("Test", "", "2026-04-10", "T10:00", "T11:00");
+            existing.setId(1);
+            existing.setReminderSent(false);
+
+            Appointment edited = makeAppointment("Test", "", "2026-04-10", "T10:00", "T11:00");
+            edited.setId(1);
+            edited.setClientId(null);
+            edited.setReminderSent(false);
+
+            when(appointmentRepository.findById(1L)).thenReturn(Optional.of(existing));
+            when(appointmentRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            Optional<Appointment> result = appointmentService.editAppointment(edited);
+
+            assertTrue(result.isPresent());
+            assertNull(result.get().getClientId());
+            verify(clientRepository, never()).findByPhoneNumber(any());
+        }
+
+        @Test
+        void returnsEmptyWhenAppointmentNotFound() {
+            Appointment appt = makeAppointment("Test", "", "2026-04-10", "T10:00", "T11:00");
+            appt.setId(999);
+            when(appointmentRepository.findById(999L)).thenReturn(Optional.empty());
+
+            Optional<Appointment> result = appointmentService.editAppointment(appt);
+
+            assertTrue(result.isEmpty());
+        }
+
+        @Test
+        void throwsWhenEndTimeBeforeStartTime() {
+            Appointment appt = makeAppointment("Test", "", "2026-04-10", "T14:00", "T10:00");
+            appt.setId(1);
+
+            assertThrows(IllegalArgumentException.class, () ->
+                    appointmentService.editAppointment(appt));
+        }
+
+        @Test
+        void resetsReminderWhenStartTimeChanges() {
+            Appointment existing = makeAppointment("Test", "", "2026-04-10", "T10:00", "T11:00");
+            existing.setId(1);
+            existing.setReminderSent(true);
+
+            Appointment edited = makeAppointment("Test", "", "2026-04-10", "T11:00", "T12:00");
+            edited.setId(1);
+            edited.setReminderSent(true);
+
+            when(appointmentRepository.findById(1L)).thenReturn(Optional.of(existing));
+            when(appointmentRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            appointmentService.editAppointment(edited);
+
+            assertFalse(edited.getReminderSent());
+        }
+
+        @Test
+        void resetsReminderWhenDateChanges() {
+            Appointment existing = makeAppointment("Test", "", "2026-04-10", "T10:00", "T11:00");
+            existing.setId(1);
+            existing.setReminderSent(true);
+
+            Appointment edited = makeAppointment("Test", "", "2026-04-11", "T10:00", "T11:00");
+            edited.setId(1);
+            edited.setReminderSent(true);
+
+            when(appointmentRepository.findById(1L)).thenReturn(Optional.of(existing));
+            when(appointmentRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            appointmentService.editAppointment(edited);
+
+            assertFalse(edited.getReminderSent());
+        }
+    }
+
+    @Nested
+    class DeleteAppointment {
+
+        @Test
+        void returnsTrueWhenAppointmentExists() {
+            Appointment appt = new Appointment();
+            appt.setId(1);
+            when(appointmentRepository.findById(1L)).thenReturn(Optional.of(appt));
+
+            assertTrue(appointmentService.deleteAppointment(appt));
+            verify(appointmentRepository).delete(appt);
+        }
+
+        @Test
+        void returnsFalseWhenAppointmentNotFound() {
+            Appointment appt = new Appointment();
+            appt.setId(999);
+            when(appointmentRepository.findById(999L)).thenReturn(Optional.empty());
+
+            assertFalse(appointmentService.deleteAppointment(appt));
+            verify(appointmentRepository, never()).delete(any());
+        }
+    }
+}

--- a/api/src/test/java/com/nail_art/appointment_book/services/AuthenticationServiceTest.java
+++ b/api/src/test/java/com/nail_art/appointment_book/services/AuthenticationServiceTest.java
@@ -1,0 +1,161 @@
+package com.nail_art.appointment_book.services;
+
+import com.nail_art.appointment_book.dtos.LoginUserDto;
+import com.nail_art.appointment_book.dtos.RegisterUserDto;
+import com.nail_art.appointment_book.entities.User;
+import com.nail_art.appointment_book.repositories.UserRepository;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthenticationServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private AuthenticationManager authenticationManager;
+
+    @Mock
+    private JwtService jwtService;
+
+    @InjectMocks
+    private AuthenticationService authenticationService;
+
+    @Nested
+    class Signup {
+
+        @Test
+        void createsNewUser() {
+            RegisterUserDto dto = new RegisterUserDto();
+            dto.setUsername("admin");
+            dto.setPassword("pass123");
+            dto.setEmail("admin@test.com");
+
+            when(userRepository.findByUsernameIgnoreCase("admin")).thenReturn(Optional.empty());
+            when(passwordEncoder.encode("pass123")).thenReturn("encoded_pass");
+            when(userRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            User result = authenticationService.signup(dto);
+
+            assertEquals("admin", result.getUsername());
+            assertEquals("encoded_pass", result.getPassword());
+            assertEquals("admin@test.com", result.getEmail());
+        }
+
+        @Test
+        void throwsWhenUsernameAlreadyExists() {
+            RegisterUserDto dto = new RegisterUserDto();
+            dto.setUsername("admin");
+            dto.setPassword("pass123");
+
+            User existing = new User();
+            existing.setUsername("admin");
+            when(userRepository.findByUsernameIgnoreCase("admin")).thenReturn(Optional.of(existing));
+
+            RuntimeException ex = assertThrows(RuntimeException.class, () ->
+                    authenticationService.signup(dto));
+
+            assertTrue(ex.getMessage().contains("admin"));
+            verify(userRepository, never()).save(any());
+        }
+
+        @Test
+        void encodesPasswordBeforeSaving() {
+            RegisterUserDto dto = new RegisterUserDto();
+            dto.setUsername("user");
+            dto.setPassword("plaintext");
+
+            when(userRepository.findByUsernameIgnoreCase("user")).thenReturn(Optional.empty());
+            when(passwordEncoder.encode("plaintext")).thenReturn("$2a$hashed");
+            when(userRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            User result = authenticationService.signup(dto);
+
+            assertEquals("$2a$hashed", result.getPassword());
+            verify(passwordEncoder).encode("plaintext");
+        }
+    }
+
+    @Nested
+    class Authenticate {
+
+        @Test
+        void returnsUserOnValidCredentials() {
+            LoginUserDto dto = new LoginUserDto();
+            dto.setUsername("admin");
+            dto.setPassword("pass123");
+
+            User user = new User();
+            user.setUsername("admin");
+
+            when(userRepository.findByUsernameIgnoreCase("admin")).thenReturn(Optional.of(user));
+
+            User result = authenticationService.authenticate(dto);
+
+            assertEquals("admin", result.getUsername());
+            verify(authenticationManager).authenticate(any(UsernamePasswordAuthenticationToken.class));
+        }
+
+        @Test
+        void throwsOnInvalidCredentials() {
+            LoginUserDto dto = new LoginUserDto();
+            dto.setUsername("admin");
+            dto.setPassword("wrong");
+
+            when(authenticationManager.authenticate(any()))
+                    .thenThrow(new BadCredentialsException("Bad credentials"));
+
+            assertThrows(BadCredentialsException.class, () ->
+                    authenticationService.authenticate(dto));
+        }
+    }
+
+    @Nested
+    class RefreshTokens {
+
+        @Test
+        void delegatesGenerateToJwtService() {
+            User user = new User();
+            user.setUsername("admin");
+
+            when(jwtService.generateRefreshToken(user)).thenReturn("refresh_token_123");
+
+            String token = authenticationService.generateRefreshToken(user);
+
+            assertEquals("refresh_token_123", token);
+            verify(jwtService).generateRefreshToken(user);
+        }
+
+        @Test
+        void delegatesValidateToJwtService() {
+            when(jwtService.validateRefreshToken("some_token")).thenReturn(true);
+
+            assertTrue(authenticationService.validateRefreshToken("some_token"));
+        }
+
+        @Test
+        void delegatesDeleteToJwtService() {
+            authenticationService.deleteRefreshToken("some_token");
+
+            verify(jwtService).deleteRefreshToken("some_token");
+        }
+    }
+}

--- a/api/src/test/java/com/nail_art/appointment_book/services/ClientServiceTest.java
+++ b/api/src/test/java/com/nail_art/appointment_book/services/ClientServiceTest.java
@@ -1,0 +1,178 @@
+package com.nail_art.appointment_book.services;
+
+import com.nail_art.appointment_book.entities.Appointment;
+import com.nail_art.appointment_book.entities.Client;
+import com.nail_art.appointment_book.repositories.AppointmentRepository;
+import com.nail_art.appointment_book.repositories.ClientRepository;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ClientServiceTest {
+
+    @Mock
+    private ClientRepository clientRepository;
+
+    @Mock
+    private CounterService counterService;
+
+    @Mock
+    private MongoTemplate mongoTemplate;
+
+    @Mock
+    private AppointmentService appointmentService;
+
+    @Mock
+    private AppointmentRepository appointmentRepository;
+
+    @InjectMocks
+    private ClientService clientService;
+
+    private Client makeClient(String name, String phone) {
+        Client client = new Client();
+        client.setName(name);
+        client.setPhoneNumber(phone);
+        return client;
+    }
+
+    @Nested
+    class CreateClient {
+
+        @Test
+        void createsClientWithUniquePhoneNumber() {
+            Client client = makeClient("Jane Doe", "330-555-1234");
+            when(clientRepository.findByPhoneNumber("330-555-1234")).thenReturn(Optional.empty());
+            when(counterService.getNextSequence("Clients")).thenReturn(1L);
+            when(clientRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            Client result = clientService.createClient(client);
+
+            assertEquals(1L, result.getId());
+            assertEquals("Jane Doe", result.getName());
+            verify(clientRepository).save(client);
+        }
+
+        @Test
+        void throwsWhenPhoneNumberAlreadyExists() {
+            Client existing = makeClient("Existing", "330-555-1234");
+            existing.setId(1L);
+            Client newClient = makeClient("New", "330-555-1234");
+
+            when(clientRepository.findByPhoneNumber("330-555-1234")).thenReturn(Optional.of(existing));
+
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+                    clientService.createClient(newClient));
+
+            assertTrue(ex.getMessage().contains("330-555-1234"));
+            verify(clientRepository, never()).save(any());
+        }
+
+        @Test
+        void allowsEmptyPhoneNumberWithoutCheck() {
+            Client client = makeClient("Walk-in", "");
+            when(counterService.getNextSequence("Clients")).thenReturn(1L);
+            when(clientRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            Client result = clientService.createClient(client);
+
+            assertEquals(1L, result.getId());
+            verify(clientRepository, never()).findByPhoneNumber(any());
+        }
+
+        @Test
+        void allowsNullPhoneNumberWithoutCheck() {
+            Client client = makeClient("Walk-in", null);
+            when(counterService.getNextSequence("Clients")).thenReturn(1L);
+            when(clientRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            Client result = clientService.createClient(client);
+
+            assertEquals(1L, result.getId());
+            verify(clientRepository, never()).findByPhoneNumber(any());
+        }
+    }
+
+    @Nested
+    class EditClient {
+
+        @Test
+        void updatesClientAndPropagesToAppointments() {
+            Client existing = makeClient("Old Name", "330-555-0000");
+            existing.setId(10L);
+
+            Client updated = makeClient("New Name", "330-555-1111");
+            updated.setId(10L);
+
+            Appointment appt = new Appointment();
+            appt.setId(1);
+            appt.setName("Old Name");
+            appt.setPhoneNumber("330-555-0000");
+            appt.setDate("2026-04-10");
+            appt.setStartTime("T10:00");
+            appt.setEndTime("T11:00");
+
+            when(clientRepository.findById(10L)).thenReturn(Optional.of(existing));
+            when(appointmentRepository.findByClientId(10L)).thenReturn(List.of(appt));
+            when(clientRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            Optional<Client> result = clientService.editClient(updated);
+
+            assertTrue(result.isPresent());
+            assertEquals("New Name", result.get().getName());
+            assertEquals("330-555-1111", result.get().getPhoneNumber());
+            verify(appointmentService).editAppointment(argThat(a ->
+                    a.getName().equals("New Name") && a.getPhoneNumber().equals("330-555-1111")));
+        }
+
+        @Test
+        void returnsEmptyWhenClientNotFound() {
+            Client client = makeClient("Test", "330-555-1234");
+            client.setId(999L);
+
+            when(clientRepository.findById(999L)).thenReturn(Optional.empty());
+
+            Optional<Client> result = clientService.editClient(client);
+
+            assertTrue(result.isEmpty());
+            verify(clientRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    class DeleteClient {
+
+        @Test
+        void returnsTrueWhenClientExists() {
+            Client client = makeClient("Test", "330-555-1234");
+            client.setId(10L);
+
+            when(clientRepository.findById(10L)).thenReturn(Optional.of(client));
+
+            assertTrue(clientService.deleteClient(client));
+            verify(clientRepository).delete(client);
+        }
+
+        @Test
+        void returnsFalseWhenClientNotFound() {
+            Client client = makeClient("Test", "330-555-1234");
+            client.setId(999L);
+
+            when(clientRepository.findById(999L)).thenReturn(Optional.empty());
+
+            assertFalse(clientService.deleteClient(client));
+            verify(clientRepository, never()).delete(any());
+        }
+    }
+}

--- a/api/src/test/java/com/nail_art/appointment_book/services/CounterServiceTest.java
+++ b/api/src/test/java/com/nail_art/appointment_book/services/CounterServiceTest.java
@@ -1,0 +1,57 @@
+package com.nail_art.appointment_book.services;
+
+import com.nail_art.appointment_book.entities.Counter;
+import com.nail_art.appointment_book.repositories.CounterRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CounterServiceTest {
+
+    @Mock
+    private CounterRepository counterRepository;
+
+    @InjectMocks
+    private CounterService counterService;
+
+    @Test
+    void incrementsExistingCounter() {
+        Counter counter = new Counter(5, "Clients");
+        when(counterRepository.findByCollectionName("Clients")).thenReturn(Optional.of(counter));
+
+        long result = counterService.getNextSequence("Clients");
+
+        assertEquals(6L, result);
+        verify(counterRepository).save(counter);
+        assertEquals(6L, counter.getSequence());
+    }
+
+    @Test
+    void createsNewCounterWhenNoneExists() {
+        when(counterRepository.findByCollectionName("NewCollection")).thenReturn(Optional.empty());
+
+        long result = counterService.getNextSequence("NewCollection");
+
+        assertEquals(1L, result);
+        verify(counterRepository).save(any(Counter.class));
+    }
+
+    @Test
+    void returnsConsecutiveValues() {
+        Counter counter = new Counter(0, "Test");
+        when(counterRepository.findByCollectionName("Test")).thenReturn(Optional.of(counter));
+
+        assertEquals(1L, counterService.getNextSequence("Test"));
+        assertEquals(2L, counterService.getNextSequence("Test"));
+        assertEquals(3L, counterService.getNextSequence("Test"));
+    }
+}

--- a/api/src/test/java/com/nail_art/appointment_book/services/EmployeeServiceTest.java
+++ b/api/src/test/java/com/nail_art/appointment_book/services/EmployeeServiceTest.java
@@ -1,0 +1,114 @@
+package com.nail_art.appointment_book.services;
+
+import com.nail_art.appointment_book.entities.Employee;
+import com.nail_art.appointment_book.repositories.EmployeeRepository;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EmployeeServiceTest {
+
+    @Mock
+    private EmployeeRepository employeeRepository;
+
+    @Mock
+    private CounterService counterService;
+
+    @InjectMocks
+    private EmployeeService employeeService;
+
+    private Employee makeEmployee(String name, String color) {
+        Employee emp = new Employee();
+        emp.setName(name);
+        emp.setColor(color);
+        return emp;
+    }
+
+    @Nested
+    class CreateEmployee {
+
+        @Test
+        void createsEmployeeWithGeneratedId() {
+            Employee emp = makeEmployee("Alice", "#FF0000");
+            when(counterService.getNextSequence("Employees")).thenReturn(5L);
+            when(employeeRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            Employee result = employeeService.createEmployee(emp);
+
+            assertEquals(5L, result.getId());
+            assertEquals("Alice", result.getName());
+            assertEquals("#FF0000", result.getColor());
+            verify(employeeRepository).save(emp);
+        }
+    }
+
+    @Nested
+    class EditEmployee {
+
+        @Test
+        void updatesNameAndColor() {
+            Employee existing = makeEmployee("Alice", "#FF0000");
+            existing.setId(5);
+
+            Employee updated = makeEmployee("Alice Smith", "#00FF00");
+            updated.setId(5);
+
+            when(employeeRepository.findById(5L)).thenReturn(Optional.of(existing));
+            when(employeeRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            Employee result = employeeService.editEmployee(updated);
+
+            assertNotNull(result);
+            assertEquals("Alice Smith", result.getName());
+            assertEquals("#00FF00", result.getColor());
+        }
+
+        @Test
+        void returnsNullWhenNotFound() {
+            Employee emp = makeEmployee("Nobody", "#000000");
+            emp.setId(999);
+            when(employeeRepository.findById(999L)).thenReturn(Optional.empty());
+
+            assertNull(employeeService.editEmployee(emp));
+            verify(employeeRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    class DeleteEmployee {
+
+        @Test
+        void deletesAndReturnsEmployee() {
+            Employee emp = makeEmployee("Alice", "#FF0000");
+            emp.setId(5);
+
+            when(employeeRepository.findById(5L)).thenReturn(Optional.of(emp));
+
+            Employee result = employeeService.deleteEmployee(emp);
+
+            assertNotNull(result);
+            assertEquals("Alice", result.getName());
+            verify(employeeRepository).delete(emp);
+        }
+
+        @Test
+        void returnsNullWhenNotFound() {
+            Employee emp = makeEmployee("Nobody", "#000000");
+            emp.setId(999);
+            when(employeeRepository.findById(999L)).thenReturn(Optional.empty());
+
+            assertNull(employeeService.deleteEmployee(emp));
+            verify(employeeRepository, never()).delete(any());
+        }
+    }
+}

--- a/api/src/test/java/com/nail_art/appointment_book/services/JwtServiceTest.java
+++ b/api/src/test/java/com/nail_art/appointment_book/services/JwtServiceTest.java
@@ -1,0 +1,163 @@
+package com.nail_art.appointment_book.services;
+
+import com.nail_art.appointment_book.entities.RefreshToken;
+import com.nail_art.appointment_book.entities.User;
+import com.nail_art.appointment_book.repositories.RefreshTokenRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class JwtServiceTest {
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @InjectMocks
+    private JwtService jwtService;
+
+    // Valid HS256 key (base64-encoded 256-bit key)
+    private static final String TEST_SECRET = "dGVzdHNlY3JldGtleXRoYXRpc2xvbmdlbm91Z2hmb3JoczI1Ng==";
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(jwtService, "secretKey", TEST_SECRET);
+        ReflectionTestUtils.setField(jwtService, "jwtExpiration", 3600000L); // 1 hour
+        ReflectionTestUtils.setField(jwtService, "refreshExpiration", 86400000L); // 24 hours
+    }
+
+    private User makeUser(String username) {
+        User user = new User();
+        user.setUsername(username);
+        user.setPassword("encoded");
+        return user;
+    }
+
+    @Nested
+    class TokenGeneration {
+
+        @Test
+        void generatesValidToken() {
+            User user = makeUser("admin");
+
+            String token = jwtService.generateToken(user);
+
+            assertNotNull(token);
+            assertFalse(token.isEmpty());
+        }
+
+        @Test
+        void extractsUsernameFromToken() {
+            User user = makeUser("admin");
+            String token = jwtService.generateToken(user);
+
+            String username = jwtService.extractUsername(token);
+
+            assertEquals("admin", username);
+        }
+
+        @Test
+        void tokenIsValidForCorrectUser() {
+            User user = makeUser("admin");
+            String token = jwtService.generateToken(user);
+
+            assertTrue(jwtService.isTokenValid(token, user));
+        }
+
+        @Test
+        void tokenIsInvalidForDifferentUser() {
+            User user = makeUser("admin");
+            User other = makeUser("other");
+            String token = jwtService.generateToken(user);
+
+            assertFalse(jwtService.isTokenValid(token, other));
+        }
+
+        @Test
+        void tokenIsNotExpiredWhenFresh() {
+            User user = makeUser("admin");
+            String token = jwtService.generateToken(user);
+
+            assertFalse(jwtService.isTokenExpired(token));
+        }
+
+        @Test
+        void expiredTokenThrowsOnParse() {
+            ReflectionTestUtils.setField(jwtService, "jwtExpiration", -1000L); // already expired
+            User user = makeUser("admin");
+            String token = jwtService.generateToken(user);
+
+            assertThrows(io.jsonwebtoken.ExpiredJwtException.class, () ->
+                    jwtService.extractUsername(token));
+        }
+    }
+
+    @Nested
+    class RefreshTokens {
+
+        @Test
+        void generatesRefreshTokenAndSaves() {
+            User user = makeUser("admin");
+            when(refreshTokenRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            String token = jwtService.generateRefreshToken(user);
+
+            assertNotNull(token);
+            verify(refreshTokenRepository).deleteRefreshTokensByUsername("admin");
+            verify(refreshTokenRepository).save(any(RefreshToken.class));
+        }
+
+        @Test
+        void validatesNonExpiredRefreshToken() {
+            RefreshToken rt = new RefreshToken();
+            rt.setToken("valid_token");
+            rt.setExpiryDate(Instant.now().plusSeconds(3600));
+
+            when(refreshTokenRepository.findByToken("valid_token")).thenReturn(Optional.of(rt));
+
+            assertTrue(jwtService.validateRefreshToken("valid_token"));
+        }
+
+        @Test
+        void rejectsExpiredRefreshToken() {
+            RefreshToken rt = new RefreshToken();
+            rt.setToken("expired_token");
+            rt.setExpiryDate(Instant.now().minusSeconds(3600));
+
+            when(refreshTokenRepository.findByToken("expired_token")).thenReturn(Optional.of(rt));
+
+            assertFalse(jwtService.validateRefreshToken("expired_token"));
+        }
+
+        @Test
+        void rejectsNonExistentRefreshToken() {
+            when(refreshTokenRepository.findByToken("fake_token")).thenReturn(Optional.empty());
+
+            assertFalse(jwtService.validateRefreshToken("fake_token"));
+        }
+
+        @Test
+        void deletesRefreshToken() {
+            RefreshToken rt = new RefreshToken();
+            rt.setToken("to_delete");
+
+            when(refreshTokenRepository.findByToken("to_delete")).thenReturn(Optional.of(rt));
+
+            jwtService.deleteRefreshToken("to_delete");
+
+            verify(refreshTokenRepository).delete(rt);
+        }
+    }
+}

--- a/api/src/test/java/com/nail_art/appointment_book/services/ServiceServiceTest.java
+++ b/api/src/test/java/com/nail_art/appointment_book/services/ServiceServiceTest.java
@@ -1,0 +1,110 @@
+package com.nail_art.appointment_book.services;
+
+import com.nail_art.appointment_book.repositories.ServiceRepository;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ServiceServiceTest {
+
+    @Mock
+    private ServiceRepository serviceRepository;
+
+    @Mock
+    private CounterService counterService;
+
+    @InjectMocks
+    private ServiceService serviceService;
+
+    private com.nail_art.appointment_book.entities.Service makeService(String name) {
+        com.nail_art.appointment_book.entities.Service svc = new com.nail_art.appointment_book.entities.Service();
+        svc.setName(name);
+        return svc;
+    }
+
+    @Nested
+    class CreateService {
+
+        @Test
+        void createsServiceWithGeneratedId() {
+            var svc = makeService("Manicure");
+            when(counterService.getNextSequence("Services")).thenReturn(3L);
+            when(serviceRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            var result = serviceService.createService(svc);
+
+            assertEquals(3L, result.getId());
+            assertEquals("Manicure", result.getName());
+            verify(serviceRepository).save(svc);
+        }
+    }
+
+    @Nested
+    class EditService {
+
+        @Test
+        void updatesName() {
+            var existing = makeService("Manicure");
+            existing.setId(3);
+
+            var updated = makeService("Gel Manicure");
+            updated.setId(3);
+
+            when(serviceRepository.findById(3L)).thenReturn(Optional.of(existing));
+            when(serviceRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+            var result = serviceService.editService(updated);
+
+            assertNotNull(result);
+            assertEquals("Gel Manicure", result.getName());
+        }
+
+        @Test
+        void returnsNullWhenNotFound() {
+            var svc = makeService("Nothing");
+            svc.setId(999);
+            when(serviceRepository.findById(999L)).thenReturn(Optional.empty());
+
+            assertNull(serviceService.editService(svc));
+            verify(serviceRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    class DeleteService {
+
+        @Test
+        void deletesAndReturnsService() {
+            var svc = makeService("Pedicure");
+            svc.setId(5);
+
+            when(serviceRepository.findById(5L)).thenReturn(Optional.of(svc));
+
+            var result = serviceService.deleteService(svc);
+
+            assertNotNull(result);
+            assertEquals("Pedicure", result.getName());
+            verify(serviceRepository).delete(svc);
+        }
+
+        @Test
+        void returnsNullWhenNotFound() {
+            var svc = makeService("Nothing");
+            svc.setId(999);
+            when(serviceRepository.findById(999L)).thenReturn(Optional.empty());
+
+            assertNull(serviceService.deleteService(svc));
+            verify(serviceRepository, never()).delete(any());
+        }
+    }
+}

--- a/client/src/ClientsPage/Clients.tsx
+++ b/client/src/ClientsPage/Clients.tsx
@@ -39,7 +39,6 @@ export default function Clients() {
     id: "",
     name: "",
     phoneNumber: "",
-    appointmentIds: [],
   });
 
   const refreshClients = async () => {
@@ -210,7 +209,7 @@ export default function Clients() {
         <ClientModal
           type="create"
           onSubmit={createClient}
-          client={{ id: "", name: "", phoneNumber: "", appointmentIds: [] }}
+          client={{ id: "", name: "", phoneNumber: "" }}
           renderEntities={refreshClients}
           isOpen={isCreateOpen}
           onClose={() => setIsCreateOpen(false)}

--- a/client/src/types/Client.ts
+++ b/client/src/types/Client.ts
@@ -2,5 +2,4 @@ export interface Client {
   id: string;
   name: string;
   phoneNumber?: string;
-  appointmentIds?: number[];
 }

--- a/cron/MergeDuplicateClients.py
+++ b/cron/MergeDuplicateClients.py
@@ -1,0 +1,155 @@
+import pymongo
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+connection_string = os.getenv("MONGO_URI")
+db_name = os.getenv("MONGO_DB", "Nail-Art")
+
+mongo_client = pymongo.MongoClient(connection_string)
+
+db = mongo_client[db_name]
+
+clients = db["Clients"]
+appointments = db["Appointments"]
+archived_appointments = db["ArchivedAppointments"]
+counters = db["Counters"]
+
+# --- Pre-migration state ---
+total_clients = clients.count_documents({})
+print(f"Total clients before migration: {total_clients}")
+
+counter_doc = counters.find_one({"collectionName": "Clients"})
+print(f"Clients counter before migration: {counter_doc['sequence'] if counter_doc else 'NOT FOUND'}")
+
+# --- Find duplicates ---
+pipeline = [
+    {"$match": {"phoneNumber": {"$ne": None, "$ne": ""}}},
+    {"$group": {
+        "_id": "$phoneNumber",
+        "count": {"$sum": 1},
+        "clients": {"$push": {"_id": "$_id", "id": "$id", "name": "$name", "phoneNumber": "$phoneNumber"}}
+    }},
+    {"$match": {"count": {"$gt": 1}}},
+    {"$sort": {"count": -1}}
+]
+
+duplicates = list(clients.aggregate(pipeline))
+
+if not duplicates:
+    print("No duplicate clients found. Nothing to do.")
+else:
+    print(f"Found {len(duplicates)} duplicate phone numbers to merge.\n")
+
+    for dup in duplicates:
+        phone = dup["_id"]
+        group = sorted(dup["clients"], key=lambda c: c["id"])
+        keeper = group[0]
+        victims = group[1:]
+
+        # Pick the longer name between keeper and victims
+        best_name = keeper["name"]
+        for v in victims:
+            if v["name"] and len(v["name"]) > len(best_name or ""):
+                best_name = v["name"]
+
+        if best_name != keeper["name"]:
+            print(f"  [{phone}] Name: keeping \"{best_name}\" (from victim) over \"{keeper['name']}\" (keeper)")
+        else:
+            victim_names = [v["name"] for v in victims]
+            print(f"  [{phone}] Name: keeping \"{best_name}\" (keeper). Victim names: {victim_names}")
+
+        # Update keeper's name if a longer one was found
+        if best_name != keeper["name"]:
+            clients.update_one(
+                {"_id": keeper["_id"]},
+                {"$set": {"name": best_name}}
+            )
+
+        for victim in victims:
+            with mongo_client.start_session() as session:
+                with session.start_transaction():
+                    # Update Appointments referencing the victim
+                    appt_result = appointments.update_many(
+                        {"clientId": victim["id"]},
+                        {"$set": {
+                            "clientId": keeper["id"],
+                            "name": best_name,
+                            "phoneNumber": keeper["phoneNumber"]
+                        }},
+                        session=session
+                    )
+                    print(f"  [{phone}] Updated {appt_result.modified_count} appointments from client {victim['id']} -> {keeper['id']}")
+
+                    # Update ArchivedAppointments referencing the victim
+                    archived_result = archived_appointments.update_many(
+                        {"clientId": victim["id"]},
+                        {"$set": {
+                            "clientId": keeper["id"],
+                            "name": best_name,
+                            "phoneNumber": keeper["phoneNumber"]
+                        }},
+                        session=session
+                    )
+                    print(f"  [{phone}] Updated {archived_result.modified_count} archived appointments from client {victim['id']} -> {keeper['id']}")
+
+                    # Delete the victim client
+                    clients.delete_one({"_id": victim["_id"]}, session=session)
+                    print(f"  [{phone}] Deleted victim client {victim['id']} (\"{victim['name']}\")")
+
+        # Reconstruct keeper's appointmentIds from actual Appointments
+        actual_appt_ids = [
+            doc["id"] for doc in appointments.find({"clientId": keeper["id"]}, {"id": 1})
+        ]
+        clients.update_one(
+            {"_id": keeper["_id"]},
+            {"$set": {"appointmentIds": actual_appt_ids}}
+        )
+        print(f"  [{phone}] Reconstructed appointmentIds for client {keeper['id']}: {len(actual_appt_ids)} appointments")
+        print()
+
+# --- Re-sync Clients counter to max(Client.id) ---
+max_id_result = list(clients.aggregate([
+    {"$group": {"_id": None, "maxId": {"$max": "$id"}}}
+]))
+
+if max_id_result:
+    max_client_id = max_id_result[0]["maxId"]
+    counters.update_one(
+        {"collectionName": "Clients"},
+        {"$max": {"sequence": max_client_id}},
+        upsert=True
+    )
+    print(f"Clients counter synced to max(Client.id) = {max_client_id}")
+
+# --- Verify no duplicates remain ---
+remaining = list(clients.aggregate(pipeline))
+if remaining:
+    print(f"\nWARNING: {len(remaining)} duplicate phone numbers still exist!")
+    for r in remaining:
+        print(f"  {r['_id']}: {r['count']} clients")
+else:
+    print("\nVerified: zero duplicate phone numbers remain.")
+
+# --- Create partial filter unique index ---
+index_name = "phoneNumber_unique_partial"
+existing_indexes = clients.index_information()
+
+if index_name in existing_indexes:
+    print(f"Index '{index_name}' already exists. Skipping creation.")
+else:
+    clients.create_index(
+        "phoneNumber",
+        unique=True,
+        name=index_name,
+        partialFilterExpression={"phoneNumber": {"$type": "string", "$gt": ""}}
+    )
+    print(f"Created partial filter unique index '{index_name}' on Clients.phoneNumber")
+
+# --- Final state ---
+total_clients_after = clients.count_documents({})
+counter_doc_after = counters.find_one({"collectionName": "Clients"})
+print(f"\nTotal clients after migration: {total_clients_after}")
+print(f"Clients counter after migration: {counter_doc_after['sequence'] if counter_doc_after else 'NOT FOUND'}")
+print("Done.")

--- a/docs/plans/2026-04-07-001-fix-duplicate-client-prevention-plan.md
+++ b/docs/plans/2026-04-07-001-fix-duplicate-client-prevention-plan.md
@@ -1,0 +1,282 @@
+---
+title: "fix: Prevent and resolve duplicate Client records by phone number"
+type: fix
+status: active
+date: 2026-04-07
+deepened: 2026-04-07
+---
+
+# fix: Prevent and resolve duplicate Client records by phone number
+
+## Overview
+
+Production MongoDB has 10 duplicate Client document pairs sharing the same `phoneNumber`. This causes `IncorrectResultSizeDataAccessException` when `ClientRepository.findByPhoneNumber()` (which returns `Optional<Client>`) finds multiple matches, crashing appointment creation. The fix involves merging existing duplicates, adding a partial filter unique index on `phoneNumber`, handling duplicate key errors at the application level, and fixing a counter sequence bug.
+
+## Problem Frame
+
+When creating an appointment for an existing client, `AppointmentService.createAppointment()` calls `clientRepository.findByPhoneNumber()` which returns `Optional<Client>`. With duplicate Client documents sharing the same phone number, this query throws `IncorrectResultSizeDataAccessException` because `Optional` expects at most one result. The salon cannot create appointments for any customer who has a duplicate Client record.
+
+Root causes:
+1. No unique index on `Client.phoneNumber` -- MongoDB allows duplicates freely
+2. `ClientService.createClient()` performs no duplicate check before saving
+3. `AppointmentService.createAppointment()` has a TOCTOU race on `findByPhoneNumber`
+4. Line 72 of `AppointmentService` uses `counterService.getNextSequence("Appointments")` instead of `"Clients"` when auto-creating clients
+
+## Requirements Trace
+
+- R1. All 10 existing duplicate Client pairs must be merged into single records
+- R2. All Appointment documents referencing merged-away clients must be updated to the surviving client
+- R3. A partial filter unique index on `Client.phoneNumber` must prevent future duplicates (excluding null/empty values)
+- R4. `DuplicateKeyException` must be caught and returned as a meaningful HTTP error
+- R5. The counter sequence bug on `AppointmentService:72` must be fixed
+- R6. The Clients counter must be re-synced to the actual max client ID after migration
+
+## Scope Boundaries
+
+- Phone number format normalization (e.g., "330-506-0180" vs "3305060180") is out of scope
+- Making `CounterService` atomic (replacing read-modify-write with `findAndModify`) is out of scope
+- Frontend changes to `ClientSelect` or `ClientModal` are out of scope
+- Adding `@Valid` to `editClient` controller is out of scope (pre-existing gap)
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `User.java:21` -- existing precedent for `@Indexed(unique = true)` in this codebase
+- `application.properties:7` -- `spring.data.mongodb.auto-index-creation=true` is enabled, so `@Indexed` annotations auto-create indexes on startup
+- `MongoConfig.java` -- existing config class where a programmatic index can be created via `@PostConstruct`
+- `GlobalExceptionHandler.java` -- catches all `Exception.class`, uses `ProblemDetail` responses, instanceof chain pattern
+- `ClientService.createClient()` -- no phone number uniqueness check
+- `AppointmentService.createAppointment():65-83` -- auto-creates clients with wrong counter sequence
+- `CounterService.getNextSequence()` -- non-atomic but out of scope for this fix
+
+### Key Observations from Production Data
+
+- 10 duplicate pairs, all with exactly 2 records per phone number
+- Two creation patterns: bulk import on 2025-01-03 (created seconds apart) and gradual re-creation over months
+- Some pairs have identical names (e.g., "Diane Perica" / "Diane Perica"), others differ (e.g., "Cheryl" / "Cheryl Harper")
+- The `ArchiveAppointments.py` cron deletes old appointments without cleaning up `Client.appointmentIds`, so stale IDs exist in those lists
+- The Clients counter is at 247 but some clients have IDs >11000 (from the Appointments counter bug)
+
+## Key Technical Decisions
+
+- **Partial filter index over sparse index:** A sparse unique index would block multiple clients with `phoneNumber = ""` (used for walk-ins). A partial filter index with `{ phoneNumber: { $type: "string", $gt: "" } }` enforces uniqueness only on non-empty phone numbers. This cannot use `@Indexed` annotation and requires programmatic index creation in `MongoConfig`.
+
+- **Index created in migration script, verified on app startup:** The migration script creates the partial filter unique index as its final step after verifying zero duplicates remain. This eliminates the deployment race window (no gap between migration and code deploy where new duplicates could slip in). The `MongoConfig` `@PostConstruct` serves as a redundant safety net that verifies the index exists on every startup (idempotent). Since partial filter indexes can't be expressed with `@Indexed`, both the migration script and the Java code use programmatic index creation.
+
+- **Keeper selection: lower ID client survives:** The lower-ID client typically has more appointments and was created first. For name discrepancies, use the longer/more complete name (e.g., "Cheryl Harper" over "Cheryl").
+
+- **Reconstruct appointmentIds from actual Appointments:** Rather than naively unioning both clients' `appointmentIds` lists (which contain stale entries from archived appointments), query `Appointments` by `clientId` after the merge to build an accurate list.
+
+- **Migration script in Python using pymongo:** The project already has Python cron scripts using pymongo in `/cron/`. Follow the same pattern for the migration script.
+
+- **Deployment order: migrate first, then deploy code:** The migration script merges duplicates and creates the unique index as its final step. The code deploy can then happen at any time -- the `@PostConstruct` index creation is a no-op if the index already exists. This eliminates the deployment coordination risk.
+
+- **App startup is intentional fail-fast:** If the `@PostConstruct` index creation encounters duplicates (i.e., migration was not run), the app will fail to start with a `BeanCreationException`. This is intentional -- the application should not run with data that violates the uniqueness invariant.
+
+- **Migration uses transactions per merge pair:** Each duplicate pair merge (update appointments, reconstruct appointmentIds, delete victim) is wrapped in a MongoDB transaction for atomicity. Atlas replica sets support multi-document transactions. If a pair merge fails, it rolls back cleanly and the script can be re-run.
+
+- **Counter re-sync uses $max to avoid race conditions:** The migration updates the Clients counter using an update with `$max` operator, which only increases the counter value, never decreases it. This is safe even if the app creates clients concurrently during migration.
+
+- **Spring Data MongoDB partial filter API note:** The `Criteria` class does not natively support `$type` + `$gt` together for `PartialIndexFilter`. The implementation will need to construct a raw `org.bson.Document` for the filter expression rather than using the `Criteria` builder.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **How to handle empty phone numbers with unique index?** Resolved: Use partial filter index that excludes empty strings and nulls.
+- **What name should the surviving client keep?** Resolved: Use the longer/more complete name from either record.
+- **Where to put the migration script?** Resolved: In `/cron/` following existing pymongo script patterns.
+- **Should the migration reconstruct appointmentIds?** Resolved: Yes, query actual Appointments rather than unioning stale lists.
+
+### Deferred to Implementation
+
+- **Exact partial filter expression syntax in Java:** Spring Data MongoDB's `Criteria` class does not natively chain `$type` and `$gt` for `PartialIndexFilter`. The implementer will need to construct a raw `org.bson.Document` (e.g., `Document.parse("{ phoneNumber: { $type: 'string', $gt: '' } }")`) for the filter expression. The pymongo syntax is straightforward.
+- **Whether the app startup gracefully handles index-already-exists:** Should be verified but MongoDB's `createIndex` is idempotent by design.
+
+## Implementation Units
+
+- [ ] **Unit 1: Migration script to merge duplicate clients and create unique index**
+
+  **Goal:** Merge all 10 duplicate Client pairs into single records, update all referencing documents, re-sync the Clients counter, and create the partial filter unique index.
+
+  **Requirements:** R1, R2, R3, R6
+
+  **Dependencies:** None (runs standalone against production MongoDB)
+
+  **Files:**
+  - Create: `cron/MergeDuplicateClients.py`
+
+  **Approach:**
+  - Take a pre-migration backup (Atlas snapshot or `mongodump` of Clients, Appointments, and ArchivedAppointments collections)
+  - Connect to MongoDB using the same connection pattern as `cron/ArchiveAppointments.py`
+  - Log pre-migration state: total client count, duplicate count, current Clients counter value
+  - Aggregate to find all phone numbers with count > 1
+  - For each duplicate group, within a MongoDB transaction:
+    - Select keeper (lowest `id`) and victim(s)
+    - Choose the longer name between keeper and victim; log both names for operator audit
+    - Update all `Appointments` where `clientId == victim.id`: set `clientId = keeper.id`, `name = keeper.name`, `phoneNumber = keeper.phoneNumber`
+    - Update all `ArchivedAppointments` where `clientId == victim.id`: set `clientId = keeper.id`, `name = keeper.name`, `phoneNumber = keeper.phoneNumber`
+    - Reconstruct keeper's `appointmentIds` by querying `Appointments.find({ clientId: keeper.id })` and collecting the `id` values
+    - Delete the victim Client document
+  - After all merges, update the `Counters` document for `"Clients"` using `$max` operator to set sequence to `max(Client.id)` -- this only increases the counter, never decreases it, making it safe if the app is running concurrently
+  - Verify zero duplicates remain via aggregation query
+  - Create the partial filter unique index on `Clients.phoneNumber` with filter `{ phoneNumber: { $type: "string", $gt: "" } }` -- this is the authoritative index creation; the Java `@PostConstruct` is a redundant safety net
+  - Make the script idempotent (safe to re-run; if no duplicates found, it skips merging; if index already exists, it skips creation)
+  - Log every action: which pairs were merged, name chosen, appointments updated, victims deleted
+
+  **Patterns to follow:**
+  - `cron/ArchiveAppointments.py` for MongoDB connection setup, pymongo usage, and script structure
+
+  **Test scenarios:**
+  - Run against production: all 10 pairs merged, zero duplicates remain
+  - All Appointment documents referencing victim client IDs now reference keeper client IDs
+  - All ArchivedAppointment documents referencing victim client IDs are also updated
+  - Appointment documents have updated `name` AND `phoneNumber` (not just `clientId`)
+  - Keeper's `appointmentIds` list matches actual Appointments in the database
+  - Clients counter is set to at least `max(Client.id)`
+  - The partial filter unique index exists on the Clients collection
+  - Re-running the script produces no changes (idempotent)
+  - If a single pair merge fails, it rolls back (transaction) and remaining pairs are still processed
+
+  **Verification:**
+  - Run the duplicate-finding aggregation query after migration: returns empty results
+  - Spot-check 2-3 merged clients: appointment counts match, names are correct
+  - Check Clients counter value matches or exceeds the highest client ID
+  - `db.Clients.getIndexes()` shows the partial filter unique index
+  - Attempt to insert a duplicate phone number via mongosh: fails with duplicate key error
+
+- [ ] **Unit 2: Add startup index verification in MongoConfig**
+
+  **Goal:** Ensure the partial filter unique index exists on every app startup as a safety net. The migration script (Unit 1) is the primary index creator; this is the redundant declarative guard.
+
+  **Requirements:** R3
+
+  **Dependencies:** Unit 1 (duplicates must be resolved and index created by migration first)
+
+  **Files:**
+  - Modify: `api/src/main/java/com/nail_art/appointment_book/configs/MongoConfig.java`
+
+  **Approach:**
+  - Inject `MongoTemplate` into `MongoConfig` (it currently only has `MongoClient`)
+  - Add a `@PostConstruct` method that creates/verifies the partial filter unique index on `Clients.phoneNumber`
+  - Use `MongoTemplate.indexOps("Clients").ensureIndex()` with a raw `org.bson.Document` for the partial filter expression (Spring Data MongoDB's `Criteria` does not support `$type` + `$gt` together for `PartialIndexFilter`)
+  - This is idempotent: if the index already exists (created by migration), MongoDB no-ops
+  - If duplicates still exist (migration was not run), index creation fails and the app will not start -- this is intentional fail-fast behavior
+
+  **Patterns to follow:**
+  - `User.java:21` for the conceptual pattern of unique indexes in this project
+
+  **Test scenarios:**
+  - App starts successfully when the index already exists (created by migration)
+  - App starts successfully when the index does not exist and no duplicates are present (creates it)
+  - App fails to start when duplicates exist (intentional fail-fast)
+  - Multiple clients with `phoneNumber = null` or `phoneNumber = ""` can coexist without conflict
+  - Re-starting the app does not error on index already existing
+
+  **Verification:**
+  - `db.Clients.getIndexes()` shows the partial filter unique index after app startup
+
+- [ ] **Unit 3: Handle DuplicateKeyException in GlobalExceptionHandler**
+
+  **Goal:** Return a meaningful 409 Conflict response when a duplicate phone number is detected, instead of a generic 500 error.
+
+  **Requirements:** R4
+
+  **Dependencies:** Unit 2 (the index must exist for this error to occur)
+
+  **Files:**
+  - Modify: `api/src/main/java/com/nail_art/appointment_book/exceptions/GlobalExceptionHandler.java`
+
+  **Approach:**
+  - Add a `DuplicateKeyException` check in the instanceof chain, before the generic `Exception` fallback
+  - Return HTTP 409 Conflict with a `ProblemDetail` containing a description like "A client with this phone number already exists"
+  - Use `org.springframework.dao.DuplicateKeyException` (Spring's wrapper around MongoDB's duplicate key error)
+
+  **Patterns to follow:**
+  - Existing instanceof chain pattern in `GlobalExceptionHandler.java` (e.g., `BadCredentialsException` -> 401)
+
+  **Test scenarios:**
+  - Creating a client with a duplicate phone number returns 409 with a descriptive message (not 500)
+  - Editing a client's phone number to an existing one returns 409
+  - Creating an appointment that auto-creates a client with a duplicate phone number returns 409
+  - Editing an appointment and changing its phone number to one belonging to a different client returns 409 (the `editAppointment` path propagates phone changes to the Client document)
+  - Non-duplicate errors still fall through to 500 as before
+
+  **Verification:**
+  - API calls that trigger duplicate key errors return 409 status code with "A client with this phone number already exists" in the response body
+
+- [ ] **Unit 4: Add duplicate check in ClientService.createClient()**
+
+  **Goal:** Check for existing clients by phone number before creating a new one, providing a better UX than relying solely on the database index.
+
+  **Requirements:** R4 (defense in depth)
+
+  **Dependencies:** None (this is a code-level guard independent of the index)
+
+  **Files:**
+  - Modify: `api/src/main/java/com/nail_art/appointment_book/services/ClientService.java`
+
+  **Approach:**
+  - In `createClient()`, before saving, call `clientRepository.findByPhoneNumber(client.getPhoneNumber())` if the phone number is non-null and non-empty
+  - If a match is found, throw an `IllegalArgumentException` or a custom exception with a descriptive message
+  - This provides an application-level guard in addition to the database-level unique index
+  - Note: The auto-create client path in `AppointmentService.createAppointment()` (lines 65-75) bypasses `ClientService.createClient()` entirely, so this guard does not cover that path. The `AppointmentService` path already has a `findByPhoneNumber` check before creating, and the database unique index serves as the final safety net for any TOCTOU race there. If two concurrent appointment requests race on the same new phone number, one will succeed and the other will get a 409 from the `DuplicateKeyException` handler -- the user retries and it works.
+
+  **Patterns to follow:**
+  - The check pattern in `AppointmentService.createAppointment():65-66`
+
+  **Test scenarios:**
+  - Creating a client with a phone number that already exists throws an error before reaching the database
+  - Creating a client with a new phone number succeeds normally
+  - Creating a client with null or empty phone number skips the check and succeeds
+
+  **Verification:**
+  - Call `POST /clients/create` with a duplicate phone number: returns an error response before the database save
+
+- [ ] **Unit 5: Fix counter sequence bug in AppointmentService**
+
+  **Goal:** Fix the wrong counter sequence name used when auto-creating clients during appointment creation, and re-sync the Clients counter.
+
+  **Requirements:** R5, R6
+
+  **Dependencies:** Unit 1 (the counter re-sync in the migration handles the current data; this prevents future drift)
+
+  **Files:**
+  - Modify: `api/src/main/java/com/nail_art/appointment_book/services/AppointmentService.java`
+
+  **Approach:**
+  - Change line 72 from `counterService.getNextSequence("Appointments")` to `counterService.getNextSequence("Clients")`
+  - This is a one-line fix
+
+  **Patterns to follow:**
+  - `ClientService.createClient():46` which correctly uses `counterService.getNextSequence("Clients")`
+
+  **Test scenarios:**
+  - Creating an appointment that auto-creates a client uses the Clients counter, not the Appointments counter
+  - The new client's ID is consistent with other clients created through `ClientService.createClient()`
+
+  **Verification:**
+  - After creating an appointment that auto-creates a client, check that the Clients counter was incremented (not just the Appointments counter)
+
+## System-Wide Impact
+
+- **Interaction graph:** `AppointmentService.createAppointment()`, `AppointmentService.editAppointment()`, `ClientService.createClient()`, and `ClientService.editClient()` all save Client documents and could trigger the unique index constraint. The `GlobalExceptionHandler` catches the resulting `DuplicateKeyException`.
+- **Error propagation:** `DuplicateKeyException` from MongoDB -> Spring's `DuplicateKeyException` -> `GlobalExceptionHandler` -> 409 ProblemDetail -> frontend shows error alert. The frontend already has generic error handling for failed API calls (`setAlert` in `AppointmentModal` and `ClientModal`).
+- **State lifecycle risks:** The migration must fully complete before the index is added. If migration is interrupted mid-way, it should be safe to re-run (idempotent). The partial filter index creation on app startup is also idempotent.
+- **API surface parity:** No new API endpoints. Error responses change from 500 to 409 for duplicate phone numbers -- this is a behavior improvement, not a breaking change.
+- **Cron script impact:** `ArchiveAppointments.py` deletes appointments but does not clean `Client.appointmentIds`. This pre-existing issue is partially addressed by Unit 1's `appointmentIds` reconstruction, but the stale-ID problem will recur over time. Out of scope for this fix.
+
+## Risks & Dependencies
+
+- **Migration must run before code deploy:** If the code deploys while duplicates still exist, the app will fail to start (`@PostConstruct` index creation fails -> `BeanCreationException`). This is intentional fail-fast behavior. Mitigation: The migration script creates the index as its final step, so the code deploy can happen any time after a successful migration.
+- **Concurrent requests during migration:** Eliminated as a risk -- the migration script now creates the unique index immediately after merging, with no gap. The `$max` counter update is also safe under concurrent traffic.
+- **Client.phoneNumber format inconsistency:** The phone number is stored as-is with no normalization. Two clients with "330-506-0180" and "3305060180" would be treated as different. This is a pre-existing issue, out of scope, but worth noting as a future improvement.
+- **editAppointment can change client phone numbers:** `AppointmentService.editAppointment()` propagates appointment name/phone changes to the linked Client document. If a user changes an appointment's phone number to one belonging to a different client, the save will trigger `DuplicateKeyException`. The 409 handler (Unit 3) catches this, but the UX may be confusing (user edited an appointment, not a client).
+- **Pre-migration backup is essential:** The migration deletes Client documents. A MongoDB Atlas snapshot or `mongodump` should be taken before running.
+
+## Sources & References
+
+- Related entity: `api/src/main/java/com/nail_art/appointment_book/entities/User.java:21` (unique index precedent)
+- Existing cron pattern: `cron/ArchiveAppointments.py`
+- Production duplicate data: 10 pairs identified via MongoDB aggregation on 2026-04-07


### PR DESCRIPTION
## Summary
- Fix duplicate client records by phone number (migration script, unique index, counter bug fix)
- Remove unused `appointmentIds` field from Client entity
- Add client linking in `editAppointment` when phone number is added to a clientless appointment
- Fix `editAppointment` bug where client lookup used request's null clientId instead of local variable
- Add duplicate phone number check in `ClientService.createClient()` and `DuplicateKeyException` handler (409)
- Add 57 unit tests across all service classes
- Add GitHub Actions CI workflow (backend tests + frontend lint/typecheck)
- Set up branch protection requiring CI checks to pass before merging

## Test plan
- [x] All 58 tests pass locally
- [ ] CI workflow runs on this PR
- [ ] Backend Tests job passes
- [ ] Frontend Lint & Typecheck job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)