### PR TITLE
feat(reminders): shift daily reminder job to 3pm ET

### DIFF
--- a/api/src/main/java/com/nail_art/appointment_book/services/SmsService.java
+++ b/api/src/main/java/com/nail_art/appointment_book/services/SmsService.java
@@ -39,7 +39,7 @@ public class SmsService {
     @Autowired
     private AppointmentService appointmentService;
 
-    @Scheduled(cron = "0 0 10 * * *", zone = "America/New_York")
+    @Scheduled(cron = "0 0 15 * * *", zone = "America/New_York")
     public void sendReminders() {
         List<Appointment> appointments = appointmentService.getAppointmentsForTomorrow();
         int sent = 0;


### PR DESCRIPTION
## Summary
- Moves the scheduled `sendReminders` job from 10:00 to 15:00 America/New_York.

## Test plan
- [ ] Confirm Render (Starter tier, always-on) fires the job at 3pm ET the day after merge.
- [ ] Verify reminder SMS delivery and logs show expected counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)