### PR TITLE
Widen content max width and raise mobile breakpoint to md

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,10 +13,11 @@ import {
   Navigate,
 } from "react-router-dom";
 import { Box, useMediaQuery, useTheme } from "@mui/material";
+import { MOBILE_BREAKPOINT } from "./constants/design";
 
 function AppContent() {
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+  const isMobile = useMediaQuery(theme.breakpoints.down(MOBILE_BREAKPOINT));
 
   return (
     <>

--- a/client/src/AppointmentsPage/Calendar/Calendar.tsx
+++ b/client/src/AppointmentsPage/Calendar/Calendar.tsx
@@ -5,11 +5,11 @@ import { Box, Paper, useMediaQuery, useTheme } from "@mui/material";
 import dayjs from "dayjs";
 import MobileCalendar from "./components/MobileCalendar";
 import PageHeader from "../../components/PageHeader";
-import { SPACING, MAX_CONTENT_WIDTH } from "../../constants/design";
+import { SPACING, MAX_CONTENT_WIDTH, MOBILE_BREAKPOINT } from "../../constants/design";
 
 const CalendarClient = () => {
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+  const isMobile = useMediaQuery(theme.breakpoints.down(MOBILE_BREAKPOINT));
   const [startDate, setStartDate] = useState(
     localStorage.getItem("startDate")
       ? dayjs(localStorage.getItem("startDate"))

--- a/client/src/AppointmentsPage/components/AppointmentModal.tsx
+++ b/client/src/AppointmentsPage/components/AppointmentModal.tsx
@@ -27,6 +27,7 @@ import ClientSelect from "./ClientSelect";
 import { DateTimeValidationError } from "@mui/x-date-pickers/models";
 import { TimeValidationError } from "@mui/x-date-pickers/models";
 import ResponsiveModal from "../../components/ResponsiveModal";
+import { MOBILE_BREAKPOINT } from "../../constants/design";
 
 const nineAM = dayjs().hour(9).minute(0).second(0);
 const ninePM = dayjs().hour(21).minute(0).second(0);
@@ -69,7 +70,7 @@ export default function AppointmentModal({
   );
   const [endTimeCustomError, setEndTimeCustomError] = useState<string>("");
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+  const isMobile = useMediaQuery(theme.breakpoints.down(MOBILE_BREAKPOINT));
 
   const errorMessage = useCallback((error: DateTimeValidationError | null) => {
     switch (error) {

--- a/client/src/Navbar/MobileBottomNav.tsx
+++ b/client/src/Navbar/MobileBottomNav.tsx
@@ -12,6 +12,7 @@ import SearchIcon from "@mui/icons-material/Search";
 import PeopleIcon from "@mui/icons-material/People";
 import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
 import MoreDrawer from "./MoreDrawer";
+import { MOBILE_BREAKPOINT } from "../constants/design";
 
 const tabs = [
   { label: "Calendar", icon: <CalendarTodayIcon />, path: "/Appointments" },
@@ -21,7 +22,7 @@ const tabs = [
 
 export default function MobileBottomNav() {
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+  const isMobile = useMediaQuery(theme.breakpoints.down(MOBILE_BREAKPOINT));
   const navigate = useNavigate();
   const location = useLocation();
   const [moreOpen, setMoreOpen] = useState(false);

--- a/client/src/Navbar/Navbar.tsx
+++ b/client/src/Navbar/Navbar.tsx
@@ -10,6 +10,7 @@ import {
   Box,
 } from "@mui/material";
 import { logout } from "../api/auth/auth";
+import { MAX_CONTENT_WIDTH } from "../constants/design";
 
 const navItems = [
   {
@@ -58,7 +59,7 @@ function Navbar() {
         border: "none",
       }}
     >
-      <Toolbar sx={{ maxWidth: 960, mx: "auto", width: "100%" }}>
+      <Toolbar sx={{ maxWidth: MAX_CONTENT_WIDTH, mx: "auto", width: "100%" }}>
         <Typography
           variant="h5"
           sx={{

--- a/client/src/components/ResponsiveModal.tsx
+++ b/client/src/components/ResponsiveModal.tsx
@@ -8,6 +8,7 @@ import {
   useMediaQuery,
   useTheme,
 } from "@mui/material";
+import { MOBILE_BREAKPOINT } from "../constants/design";
 
 export default function ResponsiveModal({
   open,
@@ -23,7 +24,7 @@ export default function ResponsiveModal({
   maxWidth?: number;
 }) {
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+  const isMobile = useMediaQuery(theme.breakpoints.down(MOBILE_BREAKPOINT));
 
   if (isMobile) {
     return (

--- a/client/src/constants/design.ts
+++ b/client/src/constants/design.ts
@@ -1,6 +1,6 @@
 import type { Breakpoint } from "@mui/material";
 
-export const MOBILE_BREAKPOINT: Breakpoint = "sm";
+export const MOBILE_BREAKPOINT: Breakpoint = "md";
 
 export const CALENDAR_COLORS = {
   border: "#e0e0e0",
@@ -17,4 +17,4 @@ export const SPACING = {
   card: { xs: 1.5, sm: 2 },
 } as const;
 
-export const MAX_CONTENT_WIDTH = 960;
+export const MAX_CONTENT_WIDTH = 1200;


### PR DESCRIPTION
## Summary
- Bump `MAX_CONTENT_WIDTH` from 960 → 1200 and switch the Navbar toolbar to use the shared constant
- Raise `MOBILE_BREAKPOINT` from `"sm"` (600px) → `"md"` (900px), and route every previously inline `theme.breakpoints.down("sm")` site through the constant (App, MobileBottomNav, ResponsiveModal, Calendar, AppointmentModal). Tablets in portrait (~768px) now get the mobile layout.

## Test plan
- [x] `npm run build` passes in `client/`
- [x] Verify desktop pages look right at the new wider 1200px cap
- [x] Verify navbar alignment matches page content
- [x] Verify tablet/portrait viewports (~768–900px) get the mobile bottom nav, mobile calendar, and swipeable drawer modals — and that those mobile views don't look stretched at the wider end of the range

🤖 Generated with [Claude Code](https://claude.com/claude-code)