### PR TITLE
fix(layout): lower mobile breakpoint to sm

### DIFF
--- a/client/src/constants/design.ts
+++ b/client/src/constants/design.ts
@@ -1,6 +1,6 @@
 import type { Breakpoint } from "@mui/material";
 
-export const MOBILE_BREAKPOINT: Breakpoint = "md";
+export const MOBILE_BREAKPOINT: Breakpoint = "sm";
 
 export const CALENDAR_COLORS = {
   border: "#e0e0e0",


### PR DESCRIPTION
## Summary
- Lowers `MOBILE_BREAKPOINT` from `md` to `sm` so only small (phone-sized) viewports get the mobile layout; tablets and larger now use the desktop layout.

## Test plan
- [ ] Verify desktop layout renders at tablet widths (≥ 600px)
- [ ] Verify mobile layout still renders on phones (< 600px)
- [ ] Spot-check navigation, calendar, and any breakpoint-driven UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)