### PR TITLE
Prove and harden tenant isolation before onboarding salon #2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,9 @@ build/
 # Build stuff
 dist/
 *.tsbuildinfo
+
+# Python
+__pycache__/
+*.pyc
+.pytest_cache/
+.venv/

--- a/api/src/main/java/com/nail_art/appointment_book/controllers/EmployeeController.java
+++ b/api/src/main/java/com/nail_art/appointment_book/controllers/EmployeeController.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
@@ -47,6 +48,7 @@ public class EmployeeController {
     }
 
     @PostMapping("/create")
+    @PreAuthorize("hasAuthority('OWNER')")
     public ResponseEntity<?> createEmployee(@Valid @RequestBody Employee employee, BindingResult result) {
         if (result.hasErrors()) {
             return ResponseEntity.badRequest().body(ControllerValidation.fieldErrors(result));
@@ -55,6 +57,7 @@ public class EmployeeController {
     }
 
     @PutMapping("/edit/{id}")
+    @PreAuthorize("hasAuthority('OWNER')")
     public ResponseEntity<Employee> editEmployee(@PathVariable UUID id, @Valid @RequestBody Employee employee) {
         Optional<Employee> editedEmployee = employeeService.editEmployee(id, employee);
         if (editedEmployee.isEmpty()) {
@@ -64,6 +67,7 @@ public class EmployeeController {
     }
 
     @DeleteMapping("/delete/{id}")
+    @PreAuthorize("hasAuthority('OWNER')")
     public ResponseEntity<Void> deleteEmployee(@PathVariable UUID id) {
         if (!employeeService.deleteEmployee(id)) {
             return ResponseEntity.notFound().build();
@@ -77,6 +81,7 @@ public class EmployeeController {
     }
 
     @PostMapping("/reorder")
+    @PreAuthorize("hasAuthority('OWNER')")
     public ResponseEntity<?> reorder(@Valid @RequestBody EmployeeReorderRequest request, BindingResult result) {
         if (result.hasErrors()) {
             return ResponseEntity.badRequest().body(ControllerValidation.fieldErrors(result));

--- a/api/src/main/java/com/nail_art/appointment_book/controllers/ServiceController.java
+++ b/api/src/main/java/com/nail_art/appointment_book/controllers/ServiceController.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
@@ -39,6 +40,7 @@ public class ServiceController {
     }
 
     @PostMapping("/create")
+    @PreAuthorize("hasAuthority('OWNER')")
     public ResponseEntity<?> createService(@Valid @RequestBody Service service, BindingResult result) {
         if (result.hasErrors()) {
             return ResponseEntity.badRequest().body(ControllerValidation.fieldErrors(result));
@@ -52,6 +54,7 @@ public class ServiceController {
     }
 
     @PutMapping("/edit/{id}")
+    @PreAuthorize("hasAuthority('OWNER')")
     public ResponseEntity<Service> editService(@PathVariable UUID id, @Valid @RequestBody Service service) {
         Optional<Service> editedService = serviceService.editService(id, service);
         if (editedService.isEmpty()) {
@@ -61,6 +64,7 @@ public class ServiceController {
     }
 
     @DeleteMapping("/delete/{id}")
+    @PreAuthorize("hasAuthority('OWNER')")
     public ResponseEntity<Void> deleteService(@PathVariable UUID id) {
         if (!serviceService.deleteService(id)) {
             return ResponseEntity.notFound().build();

--- a/api/src/main/java/com/nail_art/appointment_book/services/SmsService.java
+++ b/api/src/main/java/com/nail_art/appointment_book/services/SmsService.java
@@ -1,8 +1,10 @@
 package com.nail_art.appointment_book.services;
 
 import com.nail_art.appointment_book.entities.Appointment;
+import com.nail_art.appointment_book.entities.Organization;
 import com.nail_art.appointment_book.entities.OrganizationSettings;
 import com.nail_art.appointment_book.multitenancy.TenantContext;
+import com.nail_art.appointment_book.repositories.OrganizationRepository;
 import com.nail_art.appointment_book.repositories.OrganizationSettingsRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,15 +20,18 @@ public class SmsService {
 
     private final AppointmentService appointmentService;
     private final OrganizationSettingsRepository organizationSettingsRepository;
+    private final OrganizationRepository organizationRepository;
     private final SmsDeliveryGateway smsDeliveryGateway;
 
     public SmsService(
             AppointmentService appointmentService,
             OrganizationSettingsRepository organizationSettingsRepository,
+            OrganizationRepository organizationRepository,
             SmsDeliveryGateway smsDeliveryGateway
     ) {
         this.appointmentService = appointmentService;
         this.organizationSettingsRepository = organizationSettingsRepository;
+        this.organizationRepository = organizationRepository;
         this.smsDeliveryGateway = smsDeliveryGateway;
     }
 
@@ -44,6 +49,13 @@ public class SmsService {
     }
 
     private void sendForCurrentOrg() {
+        // Source the salon's own name and phone for THIS org, so a tenant's clients are never
+        // told they are hearing from a different salon. Organization is the tenant root (no
+        // @TenantId), keyed by the current context's organization id.
+        Organization organization = organizationRepository.findById(TenantContext.get()).orElseThrow();
+        String salonName = organization.getName();
+        String salonPhone = organization.getBusinessPhone();
+
         for (Appointment appointment : appointmentService.getAppointmentsForTomorrow()) {
             try {
                 if (appointment.getReminderSent()) {
@@ -54,7 +66,7 @@ public class SmsService {
                 }
                 SmsDeliveryGateway.Result result = smsDeliveryGateway.sendReminder(
                         appointment.getPhoneNumber(),
-                        buildReminderMessage(appointment)
+                        buildReminderMessage(appointment, salonName, salonPhone)
                 );
                 if (result == SmsDeliveryGateway.Result.SENT) {
                     appointmentService.markReminderSent(appointment.getId());
@@ -65,13 +77,16 @@ public class SmsService {
         }
     }
 
-    public static String buildReminderMessage(Appointment appointment) {
+    public static String buildReminderMessage(Appointment appointment, String salonName, String salonPhone) {
         String day = appointment.getStartsAt().getDayOfWeek().toString();
         day = day.charAt(0) + day.substring(1).toLowerCase();
-        return "Hello! This is Nail Art & Spa LLC., and this is a reminder for your appointment on "
+        String callToAction = (salonPhone == null || salonPhone.isBlank())
+                ? "Please call the salon if you "
+                : "Please call the salon at " + salonPhone + " if you ";
+        return "Hello! This is " + salonName + ", and this is a reminder for your appointment on "
                 + day + ", "
                 + appointment.getStartsAt().format(DateTimeFormatter.ofPattern("MMM d 'at' h:mm a"))
-                + ". Please call the salon at 330-758-6633 if you "
+                + ". " + callToAction
                 + "need to reschedule or cancel. We look forward to seeing you!\n\n"
                 + "Reply STOP to stop receiving messages from this number.";
     }

--- a/api/src/main/java/com/nail_art/appointment_book/services/UserService.java
+++ b/api/src/main/java/com/nail_art/appointment_book/services/UserService.java
@@ -20,7 +20,7 @@ import java.util.Set;
 
 @Service
 public class UserService {
-    private static final Set<String> VALID_ROLES = Set.of("owner", "admin", "staff");
+    private static final Set<String> VALID_ROLES = Set.of("owner", "staff");
 
     private final UserRepository userRepository;
     private final OrganizationRepository organizationRepository;
@@ -89,7 +89,7 @@ public class UserService {
 
         String normalized = role.toLowerCase(Locale.ROOT);
         if (!VALID_ROLES.contains(normalized)) {
-            throw new IllegalArgumentException("role must be one of: owner, admin, staff");
+            throw new IllegalArgumentException("role must be one of: owner, staff");
         }
         return normalized;
     }

--- a/api/src/main/resources/db/migration/V6__drop_admin_role.sql
+++ b/api/src/main/resources/db/migration/V6__drop_admin_role.sql
@@ -1,0 +1,18 @@
+-- Drop the vestigial 'admin' org role. In practice salons have only owners and staff;
+-- 'admin' was never used and muddled the org-role model with the future platform super-user
+-- (which is a User-level capability, not an org role). Two-tier model: owner / staff.
+
+-- Fail loud if any membership still uses 'admin' so the role's meaning never changes silently.
+do $$
+begin
+    if exists (select 1 from organization_users where role = 'admin') then
+        raise exception 'Cannot drop admin role: % organization_users row(s) still use it',
+            (select count(*) from organization_users where role = 'admin');
+    end if;
+end $$;
+
+alter table organization_users
+    drop constraint organization_users_role_check;
+
+alter table organization_users
+    add constraint organization_users_role_check check (role in ('owner', 'staff'));

--- a/api/src/test/java/com/nail_art/appointment_book/controllers/AuthenticationControllerIntegrationTest.java
+++ b/api/src/test/java/com/nail_art/appointment_book/controllers/AuthenticationControllerIntegrationTest.java
@@ -139,11 +139,11 @@ class AuthenticationControllerIntegrationTest extends PostgresIntegrationTest {
 
     @Test
     void refresh_afterRoleChange_returnsTokenWithNewRole() throws Exception {
-        SeededIdentity identity = identitySupport.seedIdentity("NailArt", "owner");
-        String refreshToken = identitySupport.persistRefreshToken(identity.userId(), identity.organizationId(), "owner");
+        SeededIdentity identity = identitySupport.seedIdentity("NailArt", "staff");
+        String refreshToken = identitySupport.persistRefreshToken(identity.userId(), identity.organizationId(), "staff");
 
         jdbcTemplate.update(
-                "update organization_users set role = 'admin' where organization_id = ? and user_id = ?",
+                "update organization_users set role = 'owner' where organization_id = ? and user_id = ?",
                 identity.organizationId(),
                 identity.userId()
         );
@@ -157,7 +157,7 @@ class AuthenticationControllerIntegrationTest extends PostgresIntegrationTest {
 
         JsonNode claims = identitySupport.decodeJwtPayload(objectMapper.readTree(body).get("token").asText());
 
-        assertEquals("admin", claims.get("role").asText());
+        assertEquals("owner", claims.get("role").asText());
     }
 
     private String loginBody(String username, String password) {

--- a/api/src/test/java/com/nail_art/appointment_book/controllers/CrossOrgIsolationIntegrationTest.java
+++ b/api/src/test/java/com/nail_art/appointment_book/controllers/CrossOrgIsolationIntegrationTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -155,6 +156,118 @@ class CrossOrgIsolationIntegrationTest extends PostgresIntegrationTest {
         assertThat(clientCount(ownerB.organizationId(), "330-555-2000")).isEqualTo(1);
     }
 
+    @Test
+    void readByIdEndpoints_hideOrgBRowsFromOrgA() throws Exception {
+        String token = identitySupport.bearer(ownerA);
+
+        // The documented Hibernate 6.5 PK-lookup leak class: a by-id read must go through
+        // findScopedById, never a raw findById, so org A can never fetch org B's row by id.
+        mockMvc.perform(get("/clients/{id}", clientB).header(HttpHeaders.AUTHORIZATION, token))
+                .andExpect(status().isNotFound());
+        mockMvc.perform(get("/appointments/{id}", appointmentB).header(HttpHeaders.AUTHORIZATION, token))
+                .andExpect(status().isNotFound());
+
+        // A nonexistent id is indistinguishable from a cross-org id (no existence oracle).
+        mockMvc.perform(get("/clients/{id}", UUID.randomUUID()).header(HttpHeaders.AUTHORIZATION, token))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void searchAndNameReaders_hideOrgBRowsFromOrgA() throws Exception {
+        String token = identitySupport.bearer(ownerA);
+
+        // Derived ...ContainingIgnoreCase / name finders rely entirely on the @TenantId filter.
+        mockMvc.perform(get("/employees/name/{name}", "Bea").header(HttpHeaders.AUTHORIZATION, token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[?(@.id == '%s')]".formatted(employeeB)).doesNotExist());
+        mockMvc.perform(get("/services/name/{name}", "Waxing").header(HttpHeaders.AUTHORIZATION, token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[?(@.id == '%s')]".formatted(serviceB)).doesNotExist());
+        mockMvc.perform(get("/appointments/search/{phone}", "330-555-2000").header(HttpHeaders.AUTHORIZATION, token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isEmpty());
+
+        // Paged readers with org B's identifying values must surface zero org B rows.
+        mockMvc.perform(get("/employees/").param("name", "Bea").header(HttpHeaders.AUTHORIZATION, token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[?(@.id == '%s')]".formatted(employeeB)).doesNotExist());
+        mockMvc.perform(get("/services/").param("name", "Waxing").header(HttpHeaders.AUTHORIZATION, token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[?(@.id == '%s')]".formatted(serviceB)).doesNotExist());
+        mockMvc.perform(get("/clients/").param("name", "Org B Client").header(HttpHeaders.AUTHORIZATION, token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[?(@.id == '%s')]".formatted(clientB)).doesNotExist());
+        mockMvc.perform(get("/clients/").param("phoneNumber", "330-555-2000").header(HttpHeaders.AUTHORIZATION, token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[?(@.id == '%s')]".formatted(clientB)).doesNotExist());
+
+        // /users/me must only ever describe the caller's own org.
+        mockMvc.perform(get("/users/me").header(HttpHeaders.AUTHORIZATION, token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.organization.id").value(ownerA.organizationId().toString()));
+    }
+
+    @Test
+    void deleteEndpoints_blockOrgBIdsFromOrgA() throws Exception {
+        String token = identitySupport.bearer(ownerA);
+
+        mockMvc.perform(delete("/clients/delete/{id}", clientB).header(HttpHeaders.AUTHORIZATION, token))
+                .andExpect(status().isNotFound());
+        mockMvc.perform(delete("/employees/delete/{id}", employeeB).header(HttpHeaders.AUTHORIZATION, token))
+                .andExpect(status().isNotFound());
+        mockMvc.perform(delete("/services/delete/{id}", serviceB).header(HttpHeaders.AUTHORIZATION, token))
+                .andExpect(status().isNotFound());
+        mockMvc.perform(delete("/appointments/delete/{id}", appointmentB).header(HttpHeaders.AUTHORIZATION, token))
+                .andExpect(status().isNotFound());
+
+        // Org B rows survive untouched; the appointment soft-delete (archived_at) never fired.
+        assertThat(rowExists("clients", clientB)).isTrue();
+        assertThat(rowExists("employees", employeeB)).isTrue();
+        assertThat(rowExists("services", serviceB)).isTrue();
+        assertThat(rowExists("appointments", appointmentB)).isTrue();
+        assertThat(appointmentArchivedAt(appointmentB)).isNull();
+    }
+
+    @Test
+    void bodyOnlyAppointmentEdit_blocksOrgBId() throws Exception {
+        String token = identitySupport.bearer(ownerA);
+
+        // PUT /appointments/edit takes the id in the body — a separate code path from /edit/{id}.
+        mockMvc.perform(put("/appointments/edit")
+                        .header(HttpHeaders.AUTHORIZATION, token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(appointmentBodyWithId(appointmentB, employeeA, serviceA, "Mallory", "330-555-9999")))
+                .andExpect(status().isNotFound());
+
+        assertThat(customerName(appointmentB)).isEqualTo("Org B Appointment");
+    }
+
+    @Test
+    void reorderEndpoint_cannotTouchOrgBEmployees() throws Exception {
+        String token = identitySupport.bearer(ownerA);
+        int orgBOrder = displayOrder(employeeB);
+        int orgAOrder = displayOrder(employeeA);
+
+        // Mixed payload: one of the caller's own employees plus org B's. reorder() uses an
+        // inherited findAllById that is NOT @TenantId-filtered (the documented leak), so org B's
+        // displayOrder could be rewritten. Security-correct outcome: the whole call fails and
+        // org B's row is untouched.
+        mockMvc.perform(post("/employees/reorder")
+                        .header(HttpHeaders.AUTHORIZATION, token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"items":[{"id":"%s","displayOrder":5},{"id":"%s","displayOrder":999}]}
+                                """.formatted(employeeA, employeeB)))
+                .andExpect(status().isBadRequest());
+
+        assertThat(displayOrder(employeeB))
+                .as("org B employee displayOrder must be unchanged after a cross-org reorder attempt")
+                .isEqualTo(orgBOrder);
+        assertThat(displayOrder(employeeA))
+                .as("org A employee displayOrder must be unchanged after the atomic reorder is rejected")
+                .isEqualTo(orgAOrder);
+    }
+
     private String appointmentBody(UUID employeeId, UUID serviceId, String customerName, String phoneNumber) {
         return """
                 {
@@ -167,6 +280,21 @@ class CrossOrgIsolationIntegrationTest extends PostgresIntegrationTest {
                   "showedUp": false
                 }
                 """.formatted(customerName, employeeId, serviceId, phoneNumber);
+    }
+
+    private String appointmentBodyWithId(UUID id, UUID employeeId, UUID serviceId, String customerName, String phoneNumber) {
+        return """
+                {
+                  "id": "%s",
+                  "customerName": "%s",
+                  "employeeId": "%s",
+                  "serviceIds": ["%s"],
+                  "phoneNumber": "%s",
+                  "startsAt": "2026-04-10T12:00:00-04:00",
+                  "endsAt": "2026-04-10T13:00:00-04:00",
+                  "showedUp": false
+                }
+                """.formatted(id, customerName, employeeId, serviceId, phoneNumber);
     }
 
     private UUID insertEmployee(UUID organizationId, String name, String color) {
@@ -221,6 +349,23 @@ class CrossOrgIsolationIntegrationTest extends PostgresIntegrationTest {
 
     private String customerName(UUID id) {
         return jdbcTemplate.queryForObject("select customer_name from appointments where id = ?", String.class, id);
+    }
+
+    private boolean rowExists(String tableName, UUID id) {
+        Integer count = jdbcTemplate.queryForObject(
+                "select count(*) from " + tableName + " where id = ?", Integer.class, id);
+        return count != null && count > 0;
+    }
+
+    private java.time.OffsetDateTime appointmentArchivedAt(UUID id) {
+        return jdbcTemplate.queryForObject(
+                "select archived_at from appointments where id = ?", java.time.OffsetDateTime.class, id);
+    }
+
+    private int displayOrder(UUID employeeId) {
+        Integer order = jdbcTemplate.queryForObject(
+                "select display_order from employees where id = ?", Integer.class, employeeId);
+        return order == null ? -1 : order;
     }
 
     private Integer clientCount(UUID organizationId, String phoneNumber) {

--- a/api/src/test/java/com/nail_art/appointment_book/controllers/RoleAuthorizationIntegrationTest.java
+++ b/api/src/test/java/com/nail_art/appointment_book/controllers/RoleAuthorizationIntegrationTest.java
@@ -1,0 +1,184 @@
+package com.nail_art.appointment_book.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nail_art.appointment_book.PostgresIntegrationTest;
+import com.nail_art.appointment_book.multitenancy.TenantContext;
+import com.nail_art.appointment_book.support.PostgresIdentityTestSupport;
+import com.nail_art.appointment_book.support.PostgresIdentityTestSupport.SeededIdentity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Two-tier role enforcement (owner / staff). Staff do day-to-day appointment and client work;
+ * only owners may mutate the employee roster, the service menu, or add users. Reads stay open to
+ * staff because booking requires seeing employees and services.
+ */
+class RoleAuthorizationIntegrationTest extends PostgresIntegrationTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Value("${security.jwt.secret-key}")
+    private String secretKey;
+
+    private PostgresIdentityTestSupport identitySupport;
+    private SeededIdentity owner;
+    private SeededIdentity staff;
+    private String ownerToken;
+    private String staffToken;
+    private UUID employeeId;
+    private UUID serviceId;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.clear();
+        identitySupport = new PostgresIdentityTestSupport(jdbcTemplate, passwordEncoder, objectMapper, secretKey);
+        jdbcTemplate.update("delete from appointment_services");
+        jdbcTemplate.update("delete from appointments");
+        jdbcTemplate.update("delete from clients");
+        jdbcTemplate.update("delete from services");
+        jdbcTemplate.update("delete from employees");
+        identitySupport.resetIdentityTables();
+
+        owner = identitySupport.seedIdentity("owner", "owner");
+        // staff belongs to the SAME org as owner, so any rejection is role-based, not tenant-based.
+        staff = new SeededIdentity(
+                owner.organizationId(),
+                identitySupport.seedUserInOrganization(owner.organizationId(), "staff", "staff"),
+                "staff",
+                "staff"
+        );
+        ownerToken = identitySupport.bearer(owner);
+        staffToken = identitySupport.bearer(staff);
+
+        employeeId = insertEmployee(owner.organizationId(), "Anna", "#111111");
+        serviceId = insertService(owner.organizationId(), "Gel Manicure");
+    }
+
+    @Test
+    void staff_isForbiddenFromOwnerLevelMutations() throws Exception {
+        // Roster mutations
+        mockMvc.perform(post("/employees/create").header(HttpHeaders.AUTHORIZATION, staffToken)
+                        .contentType(MediaType.APPLICATION_JSON).content("{\"name\":\"New\",\"color\":\"#abcdef\"}"))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(put("/employees/edit/{id}", employeeId).header(HttpHeaders.AUTHORIZATION, staffToken)
+                        .contentType(MediaType.APPLICATION_JSON).content("{\"name\":\"Renamed\",\"color\":\"#abcdef\"}"))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(delete("/employees/delete/{id}", employeeId).header(HttpHeaders.AUTHORIZATION, staffToken))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(post("/employees/reorder").header(HttpHeaders.AUTHORIZATION, staffToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"items\":[{\"id\":\"%s\",\"displayOrder\":3}]}".formatted(employeeId)))
+                .andExpect(status().isForbidden());
+
+        // Service menu mutations
+        mockMvc.perform(post("/services/create").header(HttpHeaders.AUTHORIZATION, staffToken)
+                        .contentType(MediaType.APPLICATION_JSON).content("{\"name\":\"Pedicure\"}"))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(put("/services/edit/{id}", serviceId).header(HttpHeaders.AUTHORIZATION, staffToken)
+                        .contentType(MediaType.APPLICATION_JSON).content("{\"name\":\"Renamed\"}"))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(delete("/services/delete/{id}", serviceId).header(HttpHeaders.AUTHORIZATION, staffToken))
+                .andExpect(status().isForbidden());
+
+        // User management
+        mockMvc.perform(post("/users").header(HttpHeaders.AUTHORIZATION, staffToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"username\":\"extra\",\"password\":\"secret-pass\",\"role\":\"staff\"}"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void owner_isAllowedOnOwnerLevelMutations() throws Exception {
+        mockMvc.perform(post("/employees/create").header(HttpHeaders.AUTHORIZATION, ownerToken)
+                        .contentType(MediaType.APPLICATION_JSON).content("{\"name\":\"New\",\"color\":\"#abcdef\"}"))
+                .andExpect(status().isCreated());
+        mockMvc.perform(post("/services/create").header(HttpHeaders.AUTHORIZATION, ownerToken)
+                        .contentType(MediaType.APPLICATION_JSON).content("{\"name\":\"Pedicure\"}"))
+                .andExpect(status().isCreated());
+        mockMvc.perform(post("/employees/reorder").header(HttpHeaders.AUTHORIZATION, ownerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"items\":[{\"id\":\"%s\",\"displayOrder\":3}]}".formatted(employeeId)))
+                .andExpect(status().isOk());
+        mockMvc.perform(post("/users").header(HttpHeaders.AUTHORIZATION, ownerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"username\":\"newstaff\",\"password\":\"secret-pass\",\"role\":\"staff\"}"))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void createUser_rejectsDroppedAdminRole() throws Exception {
+        mockMvc.perform(post("/users").header(HttpHeaders.AUTHORIZATION, ownerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"username\":\"adminuser\",\"password\":\"secret-pass\",\"role\":\"admin\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void staff_isAllowedOnFrontDeskWorkAndReads() throws Exception {
+        // Reads needed for booking
+        mockMvc.perform(get("/employees/").header(HttpHeaders.AUTHORIZATION, staffToken))
+                .andExpect(status().isOk());
+        mockMvc.perform(get("/services/").header(HttpHeaders.AUTHORIZATION, staffToken))
+                .andExpect(status().isOk());
+
+        // Front-desk client + appointment work
+        mockMvc.perform(post("/clients/create").header(HttpHeaders.AUTHORIZATION, staffToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"Walk In\",\"phoneNumber\":\"330-555-7777\"}"))
+                .andExpect(status().isCreated());
+        mockMvc.perform(post("/appointments/create").header(HttpHeaders.AUTHORIZATION, staffToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(appointmentBody(employeeId, serviceId)))
+                .andExpect(status().isCreated());
+    }
+
+    private String appointmentBody(UUID employeeId, UUID serviceId) {
+        return """
+                {
+                  "customerName": "Walk In",
+                  "employeeId": "%s",
+                  "serviceIds": ["%s"],
+                  "phoneNumber": "330-555-8888",
+                  "startsAt": "2026-04-10T12:00:00-04:00",
+                  "endsAt": "2026-04-10T13:00:00-04:00",
+                  "showedUp": false
+                }
+                """.formatted(employeeId, serviceId);
+    }
+
+    private UUID insertEmployee(UUID organizationId, String name, String color) {
+        return jdbcTemplate.queryForObject(
+                "insert into employees (organization_id, name, color) values (?, ?, ?) returning id",
+                UUID.class, organizationId, name, color);
+    }
+
+    private UUID insertService(UUID organizationId, String name) {
+        return jdbcTemplate.queryForObject(
+                "insert into services (organization_id, name) values (?, ?) returning id",
+                UUID.class, organizationId, name);
+    }
+}

--- a/api/src/test/java/com/nail_art/appointment_book/multitenancy/TenantContextIntegrationTest.java
+++ b/api/src/test/java/com/nail_art/appointment_book/multitenancy/TenantContextIntegrationTest.java
@@ -5,7 +5,6 @@ import com.nail_art.appointment_book.PostgresIntegrationTest;
 import com.nail_art.appointment_book.support.PostgresIdentityTestSupport;
 import com.nail_art.appointment_book.support.PostgresIdentityTestSupport.SeededIdentity;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -25,6 +24,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -79,8 +79,19 @@ class TenantContextIntegrationTest extends PostgresIntegrationTest {
     }
 
     @Test
-    @Disabled("verified at U4 once Employee exists with @TenantId")
-    void authedRequest_withMismatchedOrgClaim_returnsEmpty() {
+    void authedRequest_withForgedOrgClaim_isRejectedAsBadMembership() throws Exception {
+        // org A's real user, but a JWT minted with org B's org claim. The membership cross-check
+        // (existsByUserIdAndOrganizationId) must reject it before any tenant-scoped query runs —
+        // a forged org claim never opens another tenant's scope.
+        SeededIdentity orgA = identitySupport.seedIdentity("owner-a", "owner");
+        SeededIdentity orgB = identitySupport.seedIdentity("owner-b", "owner");
+
+        String forgedToken = "Bearer " + identitySupport.signedToken(
+                orgA.userId(), orgB.organizationId(), orgA.role());
+
+        mockMvc.perform(get("/employees/").header(HttpHeaders.AUTHORIZATION, forgedToken))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().string("Invalid organization membership"));
     }
 
     @Test

--- a/api/src/test/java/com/nail_art/appointment_book/repositories/AppointmentRepositoryIntegrationTest.java
+++ b/api/src/test/java/com/nail_art/appointment_book/repositories/AppointmentRepositoryIntegrationTest.java
@@ -134,6 +134,38 @@ class AppointmentRepositoryIntegrationTest extends PostgresIntegrationTest {
     }
 
     @Test
+    void tenantId_appointmentServiceLink_derivedFinders_respectDiscriminator() {
+        UUID orgBEmployee = insertEmployee(orgB, "Bea");
+        UUID orgBAppointment = insertAppointment(orgB, orgBEmployee, "Org B", "2026-04-10T10:00:00-04:00", "2026-04-10T11:00:00-04:00", null);
+        insertAppointmentService(orgB, orgBAppointment, orgBService);
+
+        // Read path used by AppointmentService.attachServiceIds: a derived finder on the embedded
+        // key column must still apply the @TenantId filter, so org A never sees org B's links.
+        List<AppointmentServiceLink> crossOrgRead = TenantContext.runAs(
+                orgA,
+                () -> appointmentServiceLinkRepository.findByIdAppointmentId(orgBAppointment)
+        );
+        assertThat(crossOrgRead)
+                .as("operation=findByIdAppointmentId activeContext=%s orgA=%s orgB=%s orgBAppointment=%s",
+                        TenantContext.get(), orgA, orgB, orgBAppointment)
+                .isEmpty();
+
+        // Write path used by AppointmentService.replaceServiceLinks: a cross-org derived delete must
+        // touch zero org B links.
+        TenantContext.runAs(orgA, () -> appointmentServiceLinkRepository.deleteByIdAppointmentId(orgBAppointment));
+
+        Integer remaining = jdbcTemplate.queryForObject(
+                "select count(*) from appointment_services where appointment_id = ?",
+                Integer.class,
+                orgBAppointment
+        );
+        assertThat(remaining)
+                .as("operation=deleteByIdAppointmentId activeContext-was=%s orgA=%s orgB=%s orgBAppointment=%s",
+                        orgA, orgA, orgB, orgBAppointment)
+                .isEqualTo(1);
+    }
+
+    @Test
     void appointmentServiceLink_compositeFkBlocksCrossOrgLink() {
         UUID appointmentId = insertAppointment(orgA, orgAEmployee, "Org A", "2026-04-10T10:00:00-04:00", "2026-04-10T11:00:00-04:00", null);
 

--- a/api/src/test/java/com/nail_art/appointment_book/repositories/EmployeeRepositoryIntegrationTest.java
+++ b/api/src/test/java/com/nail_art/appointment_book/repositories/EmployeeRepositoryIntegrationTest.java
@@ -176,6 +176,25 @@ class EmployeeRepositoryIntegrationTest extends PostgresIntegrationTest {
     }
 
     @Test
+    void tenantId_findAllById_respectsDiscriminator() {
+        UUID orgAEmployeeId = insertEmployee(orgA, "Anna", "#111111");
+        UUID orgBEmployeeId = insertEmployee(orgB, "Bea", "#222222");
+
+        // findAllById on a simple-id entity issues an `id in (:ids)` query (not EntityManager.find),
+        // so the @TenantId filter DOES apply — unlike findById/em.find. This is the path
+        // EmployeeService.reorder() relies on; locking it in guards the reorder boundary.
+        List<Employee> found = TenantContext.runAs(
+                orgA,
+                () -> employeeRepository.findAllById(List.of(orgAEmployeeId, orgBEmployeeId))
+        );
+
+        assertThat(ids(found))
+                .as("operation=findAllById activeContext=%s seedOrgA=%s seedOrgB=%s orgAEmployee=%s orgBEmployee=%s returnedIds=%s",
+                        TenantContext.get(), orgA, orgB, orgAEmployeeId, orgBEmployeeId, ids(found))
+                .containsExactly(orgAEmployeeId);
+    }
+
+    @Test
     void tenantId_derivedQuery_respectsDiscriminator() {
         UUID orgAEmployeeId = insertEmployee(orgA, "Anna", "#111111");
         UUID orgBEmployeeId = insertEmployee(orgB, "Joanne", "#222222");

--- a/api/src/test/java/com/nail_art/appointment_book/services/SmsServiceTest.java
+++ b/api/src/test/java/com/nail_art/appointment_book/services/SmsServiceTest.java
@@ -1,8 +1,10 @@
 package com.nail_art.appointment_book.services;
 
 import com.nail_art.appointment_book.entities.Appointment;
+import com.nail_art.appointment_book.entities.Organization;
 import com.nail_art.appointment_book.entities.OrganizationSettings;
 import com.nail_art.appointment_book.multitenancy.TenantContext;
+import com.nail_art.appointment_book.repositories.OrganizationRepository;
 import com.nail_art.appointment_book.repositories.OrganizationSettingsRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -13,21 +15,31 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class SmsServiceTest {
+    private static final String ORG_A_NAME = "Salon Alpha";
+    private static final String ORG_A_PHONE = "330-111-1111";
+    private static final String ORG_B_NAME = "Salon Bravo";
+    private static final String ORG_B_PHONE = "330-222-2222";
+
     @Mock
     private AppointmentService appointmentService;
 
     @Mock
     private OrganizationSettingsRepository organizationSettingsRepository;
+
+    @Mock
+    private OrganizationRepository organizationRepository;
 
     @Mock
     private SmsDeliveryGateway smsDeliveryGateway;
@@ -41,6 +53,8 @@ class SmsServiceTest {
     void sendReminders_iteratesOrgsWithRunAs() {
         UUID orgA = UUID.randomUUID();
         UUID orgB = UUID.randomUUID();
+        stubOrganization(orgA, ORG_A_NAME, ORG_A_PHONE);
+        stubOrganization(orgB, ORG_B_NAME, ORG_B_PHONE);
         Appointment orgAAppointment = appointment(UUID.randomUUID(), "330-555-1000");
         Appointment orgBAppointment = appointment(UUID.randomUUID(), "330-555-2000");
         List<UUID> contextsSeen = new ArrayList<>();
@@ -65,9 +79,53 @@ class SmsServiceTest {
     }
 
     @Test
+    void sendReminders_sendsEachOrgItsOwnSalonIdentity() {
+        UUID orgA = UUID.randomUUID();
+        UUID orgB = UUID.randomUUID();
+        stubOrganization(orgA, ORG_A_NAME, ORG_A_PHONE);
+        stubOrganization(orgB, ORG_B_NAME, ORG_B_PHONE);
+        Appointment orgAAppointment = appointment(UUID.randomUUID(), "330-555-1000");
+        Appointment orgBAppointment = appointment(UUID.randomUUID(), "330-555-2000");
+        when(organizationSettingsRepository.findBySmsRemindersEnabledTrue())
+                .thenReturn(List.of(settings(orgA), settings(orgB)));
+        when(appointmentService.getAppointmentsForTomorrow()).thenAnswer(invocation ->
+                TenantContext.get().equals(orgA) ? List.of(orgAAppointment) : List.of(orgBAppointment)
+        );
+        when(smsDeliveryGateway.sendReminder(anyString(), anyString())).thenReturn(SmsDeliveryGateway.Result.SENT);
+
+        smsService().sendReminders();
+
+        // org A's client gets org A's identity; org B's gets org B's. Never the other salon's.
+        verify(smsDeliveryGateway).sendReminder(
+                orgAAppointment.getPhoneNumber(),
+                SmsService.buildReminderMessage(orgAAppointment, ORG_A_NAME, ORG_A_PHONE));
+        verify(smsDeliveryGateway).sendReminder(
+                orgBAppointment.getPhoneNumber(),
+                SmsService.buildReminderMessage(orgBAppointment, ORG_B_NAME, ORG_B_PHONE));
+    }
+
+    @Test
+    void buildReminderMessage_carriesPerOrgSalonIdentityAndNeverAnother() {
+        Appointment appointment = appointment(UUID.randomUUID(), "330-555-1000");
+
+        String messageA = SmsService.buildReminderMessage(appointment, ORG_A_NAME, ORG_A_PHONE);
+        String messageB = SmsService.buildReminderMessage(appointment, ORG_B_NAME, ORG_B_PHONE);
+
+        assertThat(messageA)
+                .contains(ORG_A_NAME).contains(ORG_A_PHONE)
+                .doesNotContain(ORG_B_NAME).doesNotContain(ORG_B_PHONE)
+                .doesNotContain("Nail Art & Spa LLC.").doesNotContain("330-758-6633");
+        assertThat(messageB)
+                .contains(ORG_B_NAME).contains(ORG_B_PHONE)
+                .doesNotContain(ORG_A_NAME).doesNotContain(ORG_A_PHONE);
+    }
+
+    @Test
     void sendReminders_perOrgTryCatch() {
         UUID orgA = UUID.randomUUID();
         UUID orgB = UUID.randomUUID();
+        stubOrganization(orgA, ORG_A_NAME, ORG_A_PHONE);
+        stubOrganization(orgB, ORG_B_NAME, ORG_B_PHONE);
         Appointment orgAAppointment = appointment(UUID.randomUUID(), "330-555-1000");
         Appointment orgBAppointment = appointment(UUID.randomUUID(), "330-555-2000");
         when(organizationSettingsRepository.findBySmsRemindersEnabledTrue())
@@ -77,8 +135,10 @@ class SmsServiceTest {
         );
         doThrow(new RuntimeException("twilio org A outage"))
                 .when(smsDeliveryGateway)
-                .sendReminder(orgAAppointment.getPhoneNumber(), SmsService.buildReminderMessage(orgAAppointment));
-        when(smsDeliveryGateway.sendReminder(orgBAppointment.getPhoneNumber(), SmsService.buildReminderMessage(orgBAppointment)))
+                .sendReminder(orgAAppointment.getPhoneNumber(),
+                        SmsService.buildReminderMessage(orgAAppointment, ORG_A_NAME, ORG_A_PHONE));
+        when(smsDeliveryGateway.sendReminder(orgBAppointment.getPhoneNumber(),
+                SmsService.buildReminderMessage(orgBAppointment, ORG_B_NAME, ORG_B_PHONE)))
                 .thenReturn(SmsDeliveryGateway.Result.SENT);
 
         smsService().sendReminders();
@@ -89,14 +149,17 @@ class SmsServiceTest {
     @Test
     void sendReminders_twilioFailureOnOneAppointment_othersDispatch() {
         UUID orgA = UUID.randomUUID();
+        stubOrganization(orgA, ORG_A_NAME, ORG_A_PHONE);
         Appointment failed = appointment(UUID.randomUUID(), "330-555-1000");
         Appointment sent = appointment(UUID.randomUUID(), "330-555-2000");
         when(organizationSettingsRepository.findBySmsRemindersEnabledTrue()).thenReturn(List.of(settings(orgA)));
         when(appointmentService.getAppointmentsForTomorrow()).thenReturn(List.of(failed, sent));
         doThrow(new RuntimeException("transient send failure"))
                 .when(smsDeliveryGateway)
-                .sendReminder(failed.getPhoneNumber(), SmsService.buildReminderMessage(failed));
-        when(smsDeliveryGateway.sendReminder(sent.getPhoneNumber(), SmsService.buildReminderMessage(sent)))
+                .sendReminder(failed.getPhoneNumber(),
+                        SmsService.buildReminderMessage(failed, ORG_A_NAME, ORG_A_PHONE));
+        when(smsDeliveryGateway.sendReminder(sent.getPhoneNumber(),
+                SmsService.buildReminderMessage(sent, ORG_A_NAME, ORG_A_PHONE)))
                 .thenReturn(SmsDeliveryGateway.Result.SENT);
 
         smsService().sendReminders();
@@ -114,7 +177,15 @@ class SmsServiceTest {
     }
 
     private SmsService smsService() {
-        return new SmsService(appointmentService, organizationSettingsRepository, smsDeliveryGateway);
+        return new SmsService(appointmentService, organizationSettingsRepository, organizationRepository, smsDeliveryGateway);
+    }
+
+    private void stubOrganization(UUID organizationId, String name, String businessPhone) {
+        Organization organization = new Organization();
+        organization.setId(organizationId);
+        organization.setName(name);
+        organization.setBusinessPhone(businessPhone);
+        lenient().when(organizationRepository.findById(organizationId)).thenReturn(Optional.of(organization));
     }
 
     private OrganizationSettings settings(UUID organizationId) {

--- a/scripts/send_reminders.py
+++ b/scripts/send_reminders.py
@@ -15,8 +15,6 @@ load_dotenv()
 
 
 TWILIO_API_URL = "https://api.twilio.com/2010-04-01/Accounts/{sid}/Messages.json"
-SALON_NAME = "Nail Art & Spa LLC."
-SALON_PHONE = "330-758-6633"
 
 
 class SendRemindersError(Exception):
@@ -72,7 +70,8 @@ def fetch_appointments(conn: psycopg.Connection, target_date: str | None) -> lis
             a.phone_number,
             (a.starts_at at time zone o.timezone) as starts_at_local,
             o.timezone,
-            o.name as organization_name
+            o.name as organization_name,
+            o.business_phone as organization_phone
         from appointments a
         join organizations o on o.id = a.organization_id
         join organization_settings s on s.organization_id = a.organization_id
@@ -97,12 +96,17 @@ def fetch_appointments(conn: psycopg.Connection, target_date: str | None) -> lis
         return list(cur.fetchall())
 
 
-def build_message(starts_at_local: datetime) -> str:
+def build_message(starts_at_local: datetime, salon_name: str, salon_phone: str | None) -> str:
     day = starts_at_local.strftime("%A")
     when = starts_at_local.strftime("%b %-d at %-I:%M %p")
+    call_to_action = (
+        f"Please call the salon at {salon_phone} if you "
+        if salon_phone
+        else "Please call the salon if you "
+    )
     return (
-        f"Hello! This is {SALON_NAME}, and this is a reminder for your appointment on "
-        f"{day}, {when}. Please call the salon at {SALON_PHONE} if you "
+        f"Hello! This is {salon_name}, and this is a reminder for your appointment on "
+        f"{day}, {when}. {call_to_action}"
         f"need to reschedule or cancel. We look forward to seeing you!\n\n"
         f"Reply STOP to stop receiving messages from this number."
     )
@@ -165,7 +169,11 @@ def main() -> int:
             if not args.send:
                 print(preview + "  (dry run)")
                 continue
-            ok, info = send_sms(creds, a["phone_number"], build_message(a["starts_at_local"]))
+            ok, info = send_sms(
+                creds,
+                a["phone_number"],
+                build_message(a["starts_at_local"], a["organization_name"], a["organization_phone"]),
+            )
             if ok:
                 mark_sent(conn, a["id"])
                 sent += 1

--- a/scripts/test_send_reminders.py
+++ b/scripts/test_send_reminders.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+
+from send_reminders import build_message
+
+
+WHEN = datetime(2026, 4, 10, 10, 0)
+
+
+def test_build_message_uses_per_org_salon_identity() -> None:
+    message_a = build_message(WHEN, "Salon Alpha", "330-111-1111")
+    message_b = build_message(WHEN, "Salon Bravo", "330-222-2222")
+
+    # Each salon's clients hear only that salon's name and phone -- never the other's.
+    assert "Salon Alpha" in message_a and "330-111-1111" in message_a
+    assert "Salon Bravo" not in message_a and "330-222-2222" not in message_a
+    assert "Salon Bravo" in message_b and "330-222-2222" in message_b
+    assert "Salon Alpha" not in message_b and "330-111-1111" not in message_b
+
+
+def test_build_message_has_no_hardcoded_salon() -> None:
+    message = build_message(WHEN, "Salon Alpha", "330-111-1111")
+
+    assert "Nail Art & Spa LLC." not in message
+    assert "330-758-6633" not in message
+
+
+def test_build_message_tolerates_missing_business_phone() -> None:
+    message = build_message(WHEN, "Salon Alpha", None)
+
+    assert "Salon Alpha" in message
+    assert "Please call the salon if you need to reschedule or cancel." in message


### PR DESCRIPTION
## Summary

Prove the existing multi-tenant isolation actually holds against a second tenant, and fix the two concrete gaps that would bite on salon #2 go-live. The isolation foundation (`@TenantId`, scoped lookups, composite FKs) already worked — every cross-org path we attacked failed closed. This PR converts that untested hope into CI-enforced proof and closes the real gaps.

## What's in it

- **U1 — Cross-org test coverage.** Expanded the two-org suite to attack by-id reads, search/name/paged readers, deletes, the body-only `PUT /appointments/edit`, `POST /employees/reorder`, and a forged `org`-claim JWT (rejected 401 before any tenant query). All assert the security-correct outcome; all pass.
- **U2 — PK-leak audit.** No tenant-owned lookup leaks across orgs. Notably, `findAllById` on a simple-id entity issues an `id IN (:ids)` query, so the `@TenantId` filter **does** apply — `EmployeeService.reorder()` was already safe and needs no change. Added regression guards for `findAllById` and the `AppointmentServiceLink` derived finders.
- **U4 — Role enforcement + admin drop.** Added `@PreAuthorize("hasAuthority('OWNER')")` to every employee/service mutation (create/edit/delete/reorder); reads and front-desk work stay open to staff. Dropped the vestigial `admin` org role via `V6` (asserts zero rows, then rewrites the CHECK to `owner`/`staff`); `createUser` rejects `admin`.
- **U5 — Per-salon reminder identity.** `SmsService.buildReminderMessage` and `send_reminders.py` now source each org's own salon name and phone instead of hardcoding `"Nail Art & Spa LLC."` / `330-758-6633`, so a second salon's clients are never texted under the first salon's identity. `ArchiveAppointments.py` already loops per-org (verified, unchanged).

## Scope notes

- The fail-loud missing-tenant-context guard (an AOP aspect) was **intentionally dropped** as speculative defense-in-depth that doesn't fit a solo-dev setup; if real DB-level enforcement is ever wanted, Postgres RLS is the idiomatic upgrade.
- No RLS, no super-user console (deferred; the future platform super-user is a `User`-level capability, not an org role).

## Testing

Full suite green: **169 tests, 0 failures, 0 errors** (3 pre-existing `@Disabled` leak-documentation tests skipped). Python `build_message` content tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)