### PR TITLE
feat: Platform-admin operator console

### DIFF
--- a/api/src/main/java/com/nail_art/appointment_book/configs/JwtAuthenticationFilter.java
+++ b/api/src/main/java/com/nail_art/appointment_book/configs/JwtAuthenticationFilter.java
@@ -1,6 +1,8 @@
 package com.nail_art.appointment_book.configs;
 
+import com.nail_art.appointment_book.entities.User;
 import com.nail_art.appointment_book.repositories.OrganizationUserRepository;
+import com.nail_art.appointment_book.repositories.UserRepository;
 import com.nail_art.appointment_book.security.AuthenticatedPrincipal;
 import com.nail_art.appointment_book.services.JwtService;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -26,13 +28,16 @@ import java.util.UUID;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtService jwtService;
     private final OrganizationUserRepository organizationUserRepository;
+    private final UserRepository userRepository;
 
     public JwtAuthenticationFilter(
             JwtService jwtService,
-            OrganizationUserRepository organizationUserRepository
+            OrganizationUserRepository organizationUserRepository,
+            UserRepository userRepository
     ) {
         this.jwtService = jwtService;
         this.organizationUserRepository = organizationUserRepository;
+        this.userRepository = userRepository;
     }
 
     @Override
@@ -51,24 +56,44 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         try {
             final String jwt = authHeader.substring(7);
             UUID userId = jwtService.extractUserId(jwt);
-            UUID organizationId = jwtService.extractOrganizationId(jwt);
-            String role = jwtService.extractRole(jwt);
 
-            if (role == null || role.isBlank()) {
-                writeUnauthorized(response, "Invalid bearer token");
-                return;
+            AuthenticatedPrincipal principal;
+            String authority;
+
+            if (jwtService.extractIsPlatformAdmin(jwt)) {
+                // Org-less platform admin. Re-check the live flag (it may have been
+                // revoked since the token was minted) — the membership check's analogue.
+                boolean stillAdmin = userRepository.findById(userId)
+                        .map(User::isPlatformAdmin)
+                        .orElse(false);
+                if (!stillAdmin) {
+                    writeUnauthorized(response, "Platform admin access revoked");
+                    return;
+                }
+                principal = new AuthenticatedPrincipal(userId, null, null, true);
+                authority = "platform_admin";
+            } else {
+                UUID organizationId = jwtService.extractOrganizationId(jwt);
+                String role = jwtService.extractRole(jwt);
+
+                if (role == null || role.isBlank()) {
+                    writeUnauthorized(response, "Invalid bearer token");
+                    return;
+                }
+
+                if (!organizationUserRepository.existsByUserIdAndOrganizationId(userId, organizationId)) {
+                    writeUnauthorized(response, "Invalid organization membership");
+                    return;
+                }
+
+                principal = new AuthenticatedPrincipal(userId, organizationId, role, false);
+                authority = role;
             }
 
-            if (!organizationUserRepository.existsByUserIdAndOrganizationId(userId, organizationId)) {
-                writeUnauthorized(response, "Invalid organization membership");
-                return;
-            }
-
-            AuthenticatedPrincipal principal = new AuthenticatedPrincipal(userId, organizationId, role);
             UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
                     principal,
                     null,
-                    List.of(new SimpleGrantedAuthority(role))
+                    List.of(new SimpleGrantedAuthority(authority))
             );
             authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
             SecurityContextHolder.getContext().setAuthentication(authToken);

--- a/api/src/main/java/com/nail_art/appointment_book/controllers/AdminOrganizationController.java
+++ b/api/src/main/java/com/nail_art/appointment_book/controllers/AdminOrganizationController.java
@@ -1,14 +1,17 @@
 package com.nail_art.appointment_book.controllers;
 
 import com.nail_art.appointment_book.dtos.AdminTwilioConfigRequest;
+import com.nail_art.appointment_book.dtos.AdminUserUpdateRequest;
 import com.nail_art.appointment_book.dtos.CreateOrganizationRequest;
 import com.nail_art.appointment_book.dtos.OrganizationSettingsUpdateRequest;
 import com.nail_art.appointment_book.responses.AdminOrganizationSummaryResponse;
 import com.nail_art.appointment_book.responses.AdminTwilioConfigResponse;
+import com.nail_art.appointment_book.responses.AdminUserSummary;
 import com.nail_art.appointment_book.responses.CreateOrganizationResponse;
 import com.nail_art.appointment_book.responses.OrganizationSettingsResponse;
 import com.nail_art.appointment_book.services.AdminProvisioningService;
 import com.nail_art.appointment_book.services.OrganizationService;
+import com.nail_art.appointment_book.services.UserService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -35,13 +38,16 @@ import java.util.UUID;
 public class AdminOrganizationController {
     private final OrganizationService organizationService;
     private final AdminProvisioningService adminProvisioningService;
+    private final UserService userService;
 
     public AdminOrganizationController(
             OrganizationService organizationService,
-            AdminProvisioningService adminProvisioningService
+            AdminProvisioningService adminProvisioningService,
+            UserService userService
     ) {
         this.organizationService = organizationService;
         this.adminProvisioningService = adminProvisioningService;
+        this.userService = userService;
     }
 
     @GetMapping
@@ -77,5 +83,18 @@ public class AdminOrganizationController {
             @PathVariable UUID organizationId,
             @RequestBody AdminTwilioConfigRequest request) {
         return ResponseEntity.ok(organizationService.updateTwilioConfig(organizationId, request));
+    }
+
+    @GetMapping("/{organizationId}/users")
+    public ResponseEntity<List<AdminUserSummary>> listUsers(@PathVariable UUID organizationId) {
+        return ResponseEntity.ok(userService.listOrganizationUsers(organizationId));
+    }
+
+    @PutMapping("/{organizationId}/users/{userId}")
+    public ResponseEntity<AdminUserSummary> updateUser(
+            @PathVariable UUID organizationId,
+            @PathVariable UUID userId,
+            @RequestBody AdminUserUpdateRequest request) {
+        return ResponseEntity.ok(userService.updateUserCredentials(organizationId, userId, request));
     }
 }

--- a/api/src/main/java/com/nail_art/appointment_book/controllers/AdminOrganizationController.java
+++ b/api/src/main/java/com/nail_art/appointment_book/controllers/AdminOrganizationController.java
@@ -1,0 +1,51 @@
+package com.nail_art.appointment_book.controllers;
+
+import com.nail_art.appointment_book.dtos.OrganizationSettingsUpdateRequest;
+import com.nail_art.appointment_book.responses.AdminOrganizationSummaryResponse;
+import com.nail_art.appointment_book.responses.OrganizationSettingsResponse;
+import com.nail_art.appointment_book.services.OrganizationService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Platform-admin operator console. Every endpoint is gated to platform admins
+ * (the org-less is_platform_admin capability), never owners/staff. Operates on
+ * any salon by org id — these are non-@TenantId config tables, so an admin reads
+ * and writes them directly without impersonation.
+ */
+@RequestMapping("/admin/organizations")
+@RestController
+@PreAuthorize("hasAuthority('platform_admin')")
+public class AdminOrganizationController {
+    private final OrganizationService organizationService;
+
+    public AdminOrganizationController(OrganizationService organizationService) {
+        this.organizationService = organizationService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<AdminOrganizationSummaryResponse>> listSalons() {
+        return ResponseEntity.ok(organizationService.listAllSalons());
+    }
+
+    @GetMapping("/{organizationId}")
+    public ResponseEntity<OrganizationSettingsResponse> getSalon(@PathVariable UUID organizationId) {
+        return ResponseEntity.ok(organizationService.getSettings(organizationId));
+    }
+
+    @PutMapping("/{organizationId}")
+    public ResponseEntity<OrganizationSettingsResponse> updateSalon(
+            @PathVariable UUID organizationId,
+            @RequestBody OrganizationSettingsUpdateRequest request) {
+        return ResponseEntity.ok(organizationService.updateSettings(organizationId, request));
+    }
+}

--- a/api/src/main/java/com/nail_art/appointment_book/controllers/AdminOrganizationController.java
+++ b/api/src/main/java/com/nail_art/appointment_book/controllers/AdminOrganizationController.java
@@ -1,15 +1,20 @@
 package com.nail_art.appointment_book.controllers;
 
 import com.nail_art.appointment_book.dtos.AdminTwilioConfigRequest;
+import com.nail_art.appointment_book.dtos.CreateOrganizationRequest;
 import com.nail_art.appointment_book.dtos.OrganizationSettingsUpdateRequest;
 import com.nail_art.appointment_book.responses.AdminOrganizationSummaryResponse;
 import com.nail_art.appointment_book.responses.AdminTwilioConfigResponse;
+import com.nail_art.appointment_book.responses.CreateOrganizationResponse;
 import com.nail_art.appointment_book.responses.OrganizationSettingsResponse;
+import com.nail_art.appointment_book.services.AdminProvisioningService;
 import com.nail_art.appointment_book.services.OrganizationService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,14 +34,25 @@ import java.util.UUID;
 @PreAuthorize("hasAuthority('platform_admin')")
 public class AdminOrganizationController {
     private final OrganizationService organizationService;
+    private final AdminProvisioningService adminProvisioningService;
 
-    public AdminOrganizationController(OrganizationService organizationService) {
+    public AdminOrganizationController(
+            OrganizationService organizationService,
+            AdminProvisioningService adminProvisioningService
+    ) {
         this.organizationService = organizationService;
+        this.adminProvisioningService = adminProvisioningService;
     }
 
     @GetMapping
     public ResponseEntity<List<AdminOrganizationSummaryResponse>> listSalons() {
         return ResponseEntity.ok(organizationService.listAllSalons());
+    }
+
+    @PostMapping
+    public ResponseEntity<CreateOrganizationResponse> createSalon(@RequestBody CreateOrganizationRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(adminProvisioningService.createOrganization(request));
     }
 
     @GetMapping("/{organizationId}")

--- a/api/src/main/java/com/nail_art/appointment_book/controllers/AdminOrganizationController.java
+++ b/api/src/main/java/com/nail_art/appointment_book/controllers/AdminOrganizationController.java
@@ -1,7 +1,9 @@
 package com.nail_art.appointment_book.controllers;
 
+import com.nail_art.appointment_book.dtos.AdminTwilioConfigRequest;
 import com.nail_art.appointment_book.dtos.OrganizationSettingsUpdateRequest;
 import com.nail_art.appointment_book.responses.AdminOrganizationSummaryResponse;
+import com.nail_art.appointment_book.responses.AdminTwilioConfigResponse;
 import com.nail_art.appointment_book.responses.OrganizationSettingsResponse;
 import com.nail_art.appointment_book.services.OrganizationService;
 import org.springframework.http.ResponseEntity;
@@ -47,5 +49,17 @@ public class AdminOrganizationController {
             @PathVariable UUID organizationId,
             @RequestBody OrganizationSettingsUpdateRequest request) {
         return ResponseEntity.ok(organizationService.updateSettings(organizationId, request));
+    }
+
+    @GetMapping("/{organizationId}/twilio")
+    public ResponseEntity<AdminTwilioConfigResponse> getTwilio(@PathVariable UUID organizationId) {
+        return ResponseEntity.ok(organizationService.getTwilioConfig(organizationId));
+    }
+
+    @PutMapping("/{organizationId}/twilio")
+    public ResponseEntity<AdminTwilioConfigResponse> updateTwilio(
+            @PathVariable UUID organizationId,
+            @RequestBody AdminTwilioConfigRequest request) {
+        return ResponseEntity.ok(organizationService.updateTwilioConfig(organizationId, request));
     }
 }

--- a/api/src/main/java/com/nail_art/appointment_book/controllers/OrganizationController.java
+++ b/api/src/main/java/com/nail_art/appointment_book/controllers/OrganizationController.java
@@ -27,14 +27,14 @@ public class OrganizationController {
     @GetMapping
     @PreAuthorize("hasAuthority('owner')")
     public ResponseEntity<OrganizationSettingsResponse> getSettings() {
-        return ResponseEntity.ok(organizationService.getSettings(currentPrincipal()));
+        return ResponseEntity.ok(organizationService.getSettings(currentPrincipal().organizationId()));
     }
 
     @PutMapping
     @PreAuthorize("hasAuthority('owner')")
     public ResponseEntity<OrganizationSettingsResponse> updateSettings(
             @RequestBody OrganizationSettingsUpdateRequest request) {
-        return ResponseEntity.ok(organizationService.updateSettings(currentPrincipal(), request));
+        return ResponseEntity.ok(organizationService.updateSettings(currentPrincipal().organizationId(), request));
     }
 
     private AuthenticatedPrincipal currentPrincipal() {

--- a/api/src/main/java/com/nail_art/appointment_book/dtos/AdminTwilioConfigRequest.java
+++ b/api/src/main/java/com/nail_art/appointment_book/dtos/AdminTwilioConfigRequest.java
@@ -1,0 +1,15 @@
+package com.nail_art.appointment_book.dtos;
+
+/**
+ * Platform-admin Twilio config write. {@code accountSid} and {@code phoneNumber}
+ * are non-secret identifiers — set when non-blank, left untouched when blank.
+ * {@code authToken} is the only secret: set/overwritten when non-blank, left
+ * untouched when blank (so a profile-only edit never wipes a stored token). It is
+ * write-only — never returned by any read.
+ */
+public record AdminTwilioConfigRequest(
+        String accountSid,
+        String phoneNumber,
+        String authToken
+) {
+}

--- a/api/src/main/java/com/nail_art/appointment_book/dtos/AdminUserUpdateRequest.java
+++ b/api/src/main/java/com/nail_art/appointment_book/dtos/AdminUserUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.nail_art.appointment_book.dtos;
+
+/**
+ * Platform-admin update of a salon user's login credentials. Both fields optional:
+ * a blank/null field is left unchanged. {@code username} is unique (citext); a
+ * collision returns 409. {@code password} is hashed; it is write-only and never read back.
+ */
+public record AdminUserUpdateRequest(
+        String username,
+        String password
+) {
+}

--- a/api/src/main/java/com/nail_art/appointment_book/dtos/CreateOrganizationRequest.java
+++ b/api/src/main/java/com/nail_art/appointment_book/dtos/CreateOrganizationRequest.java
@@ -1,0 +1,15 @@
+package com.nail_art.appointment_book.dtos;
+
+/**
+ * Platform-admin create-salon request: a new organization plus its first owner
+ * login, provisioned in one transaction. Timezone defaults to America/New_York
+ * when blank; business phone is optional.
+ */
+public record CreateOrganizationRequest(
+        String name,
+        String timezone,
+        String businessPhone,
+        String ownerUsername,
+        String ownerPassword
+) {
+}

--- a/api/src/main/java/com/nail_art/appointment_book/entities/User.java
+++ b/api/src/main/java/com/nail_art/appointment_book/entities/User.java
@@ -34,6 +34,12 @@ public class User implements UserDetails {
     @Column(name = "password_hash", nullable = false)
     private String passwordHash;
 
+    // Platform super-user capability. A User-level flag, not an org role: a
+    // platform admin has no organization_users membership and no role. Authority
+    // for admin-only operations derives from this flag.
+    @Column(name = "is_platform_admin", nullable = false)
+    private boolean platformAdmin;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private OffsetDateTime createdAt;
@@ -81,6 +87,14 @@ public class User implements UserDetails {
 
     public void setPassword(String password) {
         this.passwordHash = password;
+    }
+
+    public boolean isPlatformAdmin() {
+        return platformAdmin;
+    }
+
+    public void setPlatformAdmin(boolean platformAdmin) {
+        this.platformAdmin = platformAdmin;
     }
 
     public OffsetDateTime getCreatedAt() {

--- a/api/src/main/java/com/nail_art/appointment_book/repositories/OrganizationUserRepository.java
+++ b/api/src/main/java/com/nail_art/appointment_book/repositories/OrganizationUserRepository.java
@@ -4,11 +4,14 @@ import com.nail_art.appointment_book.entities.OrganizationUser;
 import com.nail_art.appointment_book.entities.OrganizationUserId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface OrganizationUserRepository extends JpaRepository<OrganizationUser, OrganizationUserId> {
     boolean existsByIdUserIdAndIdOrganizationId(UUID userId, UUID organizationId);
+
+    List<OrganizationUser> findByIdOrganizationId(UUID organizationId);
 
     Optional<OrganizationUser> findFirstByIdUserIdOrderByCreatedAtAsc(UUID userId);
 
@@ -24,5 +27,9 @@ public interface OrganizationUserRepository extends JpaRepository<OrganizationUs
 
     default Optional<OrganizationUser> findByUserIdAndOrganizationId(UUID userId, UUID organizationId) {
         return findByIdUserIdAndIdOrganizationId(userId, organizationId);
+    }
+
+    default List<OrganizationUser> findByOrganizationId(UUID organizationId) {
+        return findByIdOrganizationId(organizationId);
     }
 }

--- a/api/src/main/java/com/nail_art/appointment_book/repositories/ServiceRepository.java
+++ b/api/src/main/java/com/nail_art/appointment_book/repositories/ServiceRepository.java
@@ -4,7 +4,9 @@ import com.nail_art.appointment_book.entities.Service;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -15,6 +17,17 @@ import java.util.UUID;
 public interface ServiceRepository extends JpaRepository<Service, UUID> {
     @Query("select s from Service s where s.id = :id")
     Optional<Service> findScopedById(UUID id);
+
+    /**
+     * Insert an org's "Unavailable" marker service with an explicit organization_id.
+     * Native (not @TenantId-stamped) so it runs correctly inside the platform-admin
+     * create-salon transaction, whose Hibernate session is bound to the sentinel
+     * tenant — mirrors create_organization.py's raw insert.
+     */
+    @Modifying
+    @Query(value = "insert into services (organization_id, name, is_unavailability_marker) "
+            + "values (:organizationId, :name, true)", nativeQuery = true)
+    void insertUnavailabilityMarker(@Param("organizationId") UUID organizationId, @Param("name") String name);
 
     List<Service> findByNameContainingIgnoreCase(String name);
 

--- a/api/src/main/java/com/nail_art/appointment_book/repositories/ServiceRepository.java
+++ b/api/src/main/java/com/nail_art/appointment_book/repositories/ServiceRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -24,7 +25,8 @@ public interface ServiceRepository extends JpaRepository<Service, UUID> {
      * create-salon transaction, whose Hibernate session is bound to the sentinel
      * tenant — mirrors create_organization.py's raw insert.
      */
-    @Modifying
+    @Modifying(clearAutomatically = true)
+    @Transactional
     @Query(value = "insert into services (organization_id, name, is_unavailability_marker) "
             + "values (:organizationId, :name, true)", nativeQuery = true)
     void insertUnavailabilityMarker(@Param("organizationId") UUID organizationId, @Param("name") String name);

--- a/api/src/main/java/com/nail_art/appointment_book/responses/AdminOrganizationSummaryResponse.java
+++ b/api/src/main/java/com/nail_art/appointment_book/responses/AdminOrganizationSummaryResponse.java
@@ -1,0 +1,14 @@
+package com.nail_art.appointment_book.responses;
+
+import java.util.UUID;
+
+/** One salon row in the platform-admin "all salons" list. Never carries Twilio secrets. */
+public record AdminOrganizationSummaryResponse(
+        UUID id,
+        String name,
+        String timezone,
+        String businessPhone,
+        boolean smsRemindersEnabled,
+        boolean twilioConfigured
+) {
+}

--- a/api/src/main/java/com/nail_art/appointment_book/responses/AdminTwilioConfigResponse.java
+++ b/api/src/main/java/com/nail_art/appointment_book/responses/AdminTwilioConfigResponse.java
@@ -1,0 +1,13 @@
+package com.nail_art.appointment_book.responses;
+
+/**
+ * Platform-admin Twilio config read. Exposes the non-secret identifiers and
+ * whether the salon is fully configured. The auth token is write-only and is
+ * NEVER included here.
+ */
+public record AdminTwilioConfigResponse(
+        boolean configured,
+        String accountSid,
+        String phoneNumber
+) {
+}

--- a/api/src/main/java/com/nail_art/appointment_book/responses/AdminUserSummary.java
+++ b/api/src/main/java/com/nail_art/appointment_book/responses/AdminUserSummary.java
@@ -1,0 +1,7 @@
+package com.nail_art.appointment_book.responses;
+
+import java.util.UUID;
+
+/** One user (owner or staff) within a salon, for the platform-admin console. */
+public record AdminUserSummary(UUID id, String username, String role) {
+}

--- a/api/src/main/java/com/nail_art/appointment_book/responses/CreateOrganizationResponse.java
+++ b/api/src/main/java/com/nail_art/appointment_book/responses/CreateOrganizationResponse.java
@@ -1,0 +1,12 @@
+package com.nail_art.appointment_book.responses;
+
+import java.util.UUID;
+
+/** Result of provisioning a salon: the new org and its first owner login. */
+public record CreateOrganizationResponse(
+        UUID organizationId,
+        String name,
+        UUID ownerUserId,
+        String ownerUsername
+) {
+}

--- a/api/src/main/java/com/nail_art/appointment_book/responses/MeResponse.java
+++ b/api/src/main/java/com/nail_art/appointment_book/responses/MeResponse.java
@@ -2,8 +2,14 @@ package com.nail_art.appointment_book.responses;
 
 import java.util.UUID;
 
+/**
+ * Identity payload for the current session. For a platform admin, {@code role} is
+ * null, {@code isPlatformAdmin} is true, and {@code organization} is null (org-less).
+ * For owners/staff, {@code role} is set, {@code isPlatformAdmin} is false, and
+ * {@code organization} is populated.
+ */
 public record MeResponse(UserSummary user, OrganizationSummary organization) {
-    public record UserSummary(UUID id, String username, String role) {
+    public record UserSummary(UUID id, String username, String role, boolean isPlatformAdmin) {
     }
 
     public record OrganizationSummary(UUID id, String name, String timezone, String businessPhone) {

--- a/api/src/main/java/com/nail_art/appointment_book/security/AuthenticatedPrincipal.java
+++ b/api/src/main/java/com/nail_art/appointment_book/security/AuthenticatedPrincipal.java
@@ -2,5 +2,14 @@ package com.nail_art.appointment_book.security;
 
 import java.util.UUID;
 
-public record AuthenticatedPrincipal(UUID userId, UUID organizationId, String role) {
+/**
+ * The authenticated caller. Two shapes:
+ * <ul>
+ *   <li>Org member (owner/staff): {@code organizationId} and {@code role} are set,
+ *       {@code platformAdmin} is false.</li>
+ *   <li>Platform admin: {@code organizationId} and {@code role} are null,
+ *       {@code platformAdmin} is true. Org-less; authority comes from the flag.</li>
+ * </ul>
+ */
+public record AuthenticatedPrincipal(UUID userId, UUID organizationId, String role, boolean platformAdmin) {
 }

--- a/api/src/main/java/com/nail_art/appointment_book/services/AdminProvisioningService.java
+++ b/api/src/main/java/com/nail_art/appointment_book/services/AdminProvisioningService.java
@@ -1,0 +1,95 @@
+package com.nail_art.appointment_book.services;
+
+import com.nail_art.appointment_book.dtos.CreateOrganizationRequest;
+import com.nail_art.appointment_book.entities.Organization;
+import com.nail_art.appointment_book.entities.OrganizationSettings;
+import com.nail_art.appointment_book.entities.User;
+import com.nail_art.appointment_book.repositories.OrganizationRepository;
+import com.nail_art.appointment_book.repositories.OrganizationSettingsRepository;
+import com.nail_art.appointment_book.repositories.ServiceRepository;
+import com.nail_art.appointment_book.responses.CreateOrganizationResponse;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+/**
+ * Platform-admin salon provisioning: create an organization, its settings row,
+ * its first owner login, and the "Unavailable" marker service in one transaction
+ * — the server-side equivalent of create_organization.py +
+ * bootstrap_organization_owner.py. The owner is created through
+ * {@link UserService} so password hashing and the duplicate-username guard match
+ * the normal user-creation path; a failure anywhere rolls the whole salon back.
+ */
+@org.springframework.stereotype.Service
+public class AdminProvisioningService {
+    private static final String DEFAULT_TIMEZONE = "America/New_York";
+    private static final String UNAVAILABILITY_MARKER_NAME = "Unavailable";
+
+    private final OrganizationRepository organizationRepository;
+    private final OrganizationSettingsRepository organizationSettingsRepository;
+    private final ServiceRepository serviceRepository;
+    private final UserService userService;
+
+    public AdminProvisioningService(
+            OrganizationRepository organizationRepository,
+            OrganizationSettingsRepository organizationSettingsRepository,
+            ServiceRepository serviceRepository,
+            UserService userService
+    ) {
+        this.organizationRepository = organizationRepository;
+        this.organizationSettingsRepository = organizationSettingsRepository;
+        this.serviceRepository = serviceRepository;
+        this.userService = userService;
+    }
+
+    @Transactional
+    public CreateOrganizationResponse createOrganization(CreateOrganizationRequest request) {
+        if (request == null) {
+            throw new IllegalArgumentException("request body is required");
+        }
+        String name = requireText(request.name(), "name");
+        String ownerUsername = requireText(request.ownerUsername(), "ownerUsername");
+        String ownerPassword = requireText(request.ownerPassword(), "ownerPassword");
+        String timezone = isPresent(request.timezone()) ? request.timezone() : DEFAULT_TIMEZONE;
+
+        organizationRepository.findByName(name).ifPresent(existing -> {
+            throw new DataIntegrityViolationException("organization already exists: " + name);
+        });
+
+        Organization organization = new Organization();
+        organization.setName(name);
+        organization.setTimezone(timezone);
+        organization.setBusinessPhone(request.businessPhone());
+        Organization savedOrganization = organizationRepository.saveAndFlush(organization);
+        UUID organizationId = savedOrganization.getId();
+
+        OrganizationSettings settings = new OrganizationSettings();
+        settings.setOrganizationId(organizationId);
+        settings.setSmsRemindersEnabled(false);
+        organizationSettingsRepository.save(settings);
+
+        // The marker service is tenant-owned (@TenantId), but this transaction's
+        // Hibernate session is bound to the sentinel tenant (the admin is org-less),
+        // so a JPA save would stamp the wrong organization_id. Insert it natively
+        // with an explicit org id instead — same transaction, correct FK.
+        serviceRepository.insertUnavailabilityMarker(organizationId, UNAVAILABILITY_MARKER_NAME);
+
+        User owner = userService.createUserInOrganization(
+                organizationId, ownerUsername, null, ownerPassword, "owner");
+
+        return new CreateOrganizationResponse(
+                organizationId, savedOrganization.getName(), owner.getId(), owner.getUsername());
+    }
+
+    private static boolean isPresent(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private static String requireText(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " is required");
+        }
+        return value;
+    }
+}

--- a/api/src/main/java/com/nail_art/appointment_book/services/AuthenticationService.java
+++ b/api/src/main/java/com/nail_art/appointment_book/services/AuthenticationService.java
@@ -47,11 +47,17 @@ public class AuthenticationService {
     }
 
     public String generateAccessToken(User user) {
+        if (user.isPlatformAdmin()) {
+            return jwtService.generateAdminToken(user);
+        }
         OrganizationUser membership = getPrimaryMembership(user);
         return jwtService.generateToken(user, membership.getOrganizationId(), membership.getRole());
     }
 
     public String generateRefreshToken(User user) {
+        if (user.isPlatformAdmin()) {
+            return jwtService.generateAdminRefreshToken(user);
+        }
         OrganizationUser membership = getPrimaryMembership(user);
         return jwtService.generateRefreshToken(user, membership.getOrganizationId(), membership.getRole());
     }
@@ -62,9 +68,19 @@ public class AuthenticationService {
         }
 
         UUID userId = jwtService.extractUserId(refreshToken);
-        UUID organizationId = jwtService.extractOrganizationId(refreshToken);
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BadCredentialsException("User not found"));
+
+        // Platform admins are org-less: re-check the live flag (it may have been
+        // revoked since the refresh token was minted) and mint a fresh admin token.
+        if (jwtService.extractIsPlatformAdmin(refreshToken)) {
+            if (!user.isPlatformAdmin()) {
+                throw new BadCredentialsException("Platform admin access revoked");
+            }
+            return jwtService.generateAdminToken(user);
+        }
+
+        UUID organizationId = jwtService.extractOrganizationId(refreshToken);
         OrganizationUser membership = organizationUserRepository.findByUserIdAndOrganizationId(userId, organizationId)
                 .orElseThrow(() -> new BadCredentialsException("Organization membership not found"));
 
@@ -86,6 +102,7 @@ public class AuthenticationService {
         sanitized.setEmail(user.getEmail());
         sanitized.setCreatedAt(user.getCreatedAt());
         sanitized.setUpdatedAt(user.getUpdatedAt());
+        sanitized.setPlatformAdmin(user.isPlatformAdmin());
         return sanitized;
     }
 }

--- a/api/src/main/java/com/nail_art/appointment_book/services/JwtService.java
+++ b/api/src/main/java/com/nail_art/appointment_book/services/JwtService.java
@@ -54,6 +54,11 @@ public class JwtService {
         return extractClaim(token, claims -> claims.get("role", String.class));
     }
 
+    /** True only when the token carries the {@code admin=true} claim (a platform-admin token). */
+    public boolean extractIsPlatformAdmin(String token) {
+        return Boolean.TRUE.equals(extractClaim(token, claims -> claims.get("admin", Boolean.class)));
+    }
+
     public <T> T extractClaim(String token, Function<Claims, T> claimsResolver) {
         final Claims claims = extractAllClaims(token);
         return claimsResolver.apply(claims);
@@ -72,6 +77,13 @@ public class JwtService {
 
     public String generateToken(Map<String, Object> extraClaims, UserDetails userDetails) {
         return buildToken(extraClaims, userDetails, jwtExpiration);
+    }
+
+    /** Access token for an org-less platform admin: sub=userId, admin=true, no org/role. */
+    public String generateAdminToken(User user) {
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("admin", true);
+        return buildToken(claims, user.getId().toString(), jwtExpiration);
     }
 
     public long getExpirationTime() {
@@ -105,6 +117,23 @@ public class JwtService {
         Map<String, Object> claims = new HashMap<>();
         claims.put("org", organizationId.toString());
         claims.put("role", role);
+        claims.put("jti", UUID.randomUUID().toString());
+
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setUserId(user.getId());
+        refreshToken.setToken(buildToken(claims, user.getId().toString(), refreshExpiration));
+        refreshToken.setExpiryDate(Instant.now().plusMillis(refreshExpiration));
+        refreshTokenRepository.save(refreshToken);
+        return refreshToken.getToken();
+    }
+
+    /** Refresh token for an org-less platform admin: sub=userId, admin=true, jti, no org/role. */
+    @Transactional
+    public String generateAdminRefreshToken(User user) {
+        refreshTokenRepository.deleteByUserId(user.getId());
+
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("admin", true);
         claims.put("jti", UUID.randomUUID().toString());
 
         RefreshToken refreshToken = new RefreshToken();

--- a/api/src/main/java/com/nail_art/appointment_book/services/OrganizationService.java
+++ b/api/src/main/java/com/nail_art/appointment_book/services/OrganizationService.java
@@ -6,7 +6,6 @@ import com.nail_art.appointment_book.entities.OrganizationSettings;
 import com.nail_art.appointment_book.repositories.OrganizationRepository;
 import com.nail_art.appointment_book.repositories.OrganizationSettingsRepository;
 import com.nail_art.appointment_book.responses.OrganizationSettingsResponse;
-import com.nail_art.appointment_book.security.AuthenticatedPrincipal;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,8 +26,7 @@ public class OrganizationService {
     }
 
     @Transactional(readOnly = true)
-    public OrganizationSettingsResponse getSettings(AuthenticatedPrincipal principal) {
-        UUID organizationId = principal.organizationId();
+    public OrganizationSettingsResponse getSettings(UUID organizationId) {
         Organization organization = organizationRepository.findById(organizationId)
                 .orElseThrow(() -> new BadCredentialsException("Organization not found"));
         OrganizationSettings settings = organizationSettingsRepository.findById(organizationId).orElse(null);
@@ -36,18 +34,18 @@ public class OrganizationService {
     }
 
     /**
-     * Owners update profile (name, business phone, timezone) and the SMS toggle.
-     * Twilio credentials are operator-managed and never touched here. The toggle
-     * can only be turned on when Twilio is already configured (a hard 400); a
-     * profile-only edit leaves the stored flag untouched, so a salon's reminders
-     * survive until the operator runs the credential cutover.
+     * Update profile (name, business phone, timezone) and the SMS toggle for one
+     * org. Shared by the owner Settings endpoint (scoped to the caller's own org)
+     * and the platform-admin console (scoped to a target org id). Twilio
+     * credentials are not touched here. The toggle can only be turned on when
+     * Twilio is already configured (a hard 400); a profile-only edit leaves the
+     * stored flag untouched, so a salon's reminders survive until creds are set.
      */
     @Transactional
     public OrganizationSettingsResponse updateSettings(
-            AuthenticatedPrincipal principal,
+            UUID organizationId,
             OrganizationSettingsUpdateRequest request
     ) {
-        UUID organizationId = principal.organizationId();
         Organization organization = organizationRepository.findById(organizationId)
                 .orElseThrow(() -> new BadCredentialsException("Organization not found"));
         OrganizationSettings settings = organizationSettingsRepository.findById(organizationId)

--- a/api/src/main/java/com/nail_art/appointment_book/services/OrganizationService.java
+++ b/api/src/main/java/com/nail_art/appointment_book/services/OrganizationService.java
@@ -1,11 +1,13 @@
 package com.nail_art.appointment_book.services;
 
+import com.nail_art.appointment_book.dtos.AdminTwilioConfigRequest;
 import com.nail_art.appointment_book.dtos.OrganizationSettingsUpdateRequest;
 import com.nail_art.appointment_book.entities.Organization;
 import com.nail_art.appointment_book.entities.OrganizationSettings;
 import com.nail_art.appointment_book.repositories.OrganizationRepository;
 import com.nail_art.appointment_book.repositories.OrganizationSettingsRepository;
 import com.nail_art.appointment_book.responses.AdminOrganizationSummaryResponse;
+import com.nail_art.appointment_book.responses.AdminTwilioConfigResponse;
 import com.nail_art.appointment_book.responses.OrganizationSettingsResponse;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.stereotype.Service;
@@ -18,13 +20,16 @@ import java.util.UUID;
 public class OrganizationService {
     private final OrganizationRepository organizationRepository;
     private final OrganizationSettingsRepository organizationSettingsRepository;
+    private final TwilioCredentialsService twilioCredentialsService;
 
     public OrganizationService(
             OrganizationRepository organizationRepository,
-            OrganizationSettingsRepository organizationSettingsRepository
+            OrganizationSettingsRepository organizationSettingsRepository,
+            TwilioCredentialsService twilioCredentialsService
     ) {
         this.organizationRepository = organizationRepository;
         this.organizationSettingsRepository = organizationSettingsRepository;
+        this.twilioCredentialsService = twilioCredentialsService;
     }
 
     /**
@@ -105,6 +110,55 @@ public class OrganizationService {
         organizationSettingsRepository.save(settings);
 
         return toResponse(organization, settings, configured);
+    }
+
+    /**
+     * Platform-admin read of a salon's Twilio config. Returns the non-secret
+     * identifiers and the configured flag; the auth token is never read back.
+     */
+    @Transactional(readOnly = true)
+    public AdminTwilioConfigResponse getTwilioConfig(UUID organizationId) {
+        organizationRepository.findById(organizationId)
+                .orElseThrow(() -> new BadCredentialsException("Organization not found"));
+        OrganizationSettings settings = organizationSettingsRepository.findById(organizationId).orElse(null);
+        return new AdminTwilioConfigResponse(
+                isConfigured(organizationId, settings),
+                settings == null ? null : settings.getTwilioAccountSid(),
+                settings == null ? null : settings.getTwilioPhoneNumber()
+        );
+    }
+
+    /**
+     * Platform-admin write of a salon's Twilio config. SID/phone are set when
+     * non-blank (left untouched otherwise); the auth token is encrypted via
+     * pgcrypto only when non-blank, so a profile-only edit never wipes a stored
+     * token. The settings row is flushed before the token upsert so both writes
+     * land on the same row deterministically.
+     */
+    @Transactional
+    public AdminTwilioConfigResponse updateTwilioConfig(UUID organizationId, AdminTwilioConfigRequest request) {
+        organizationRepository.findById(organizationId)
+                .orElseThrow(() -> new BadCredentialsException("Organization not found"));
+        OrganizationSettings settings = organizationSettingsRepository.findById(organizationId)
+                .orElseGet(() -> {
+                    OrganizationSettings created = new OrganizationSettings();
+                    created.setOrganizationId(organizationId);
+                    return created;
+                });
+
+        if (isPresent(request.accountSid())) {
+            settings.setTwilioAccountSid(request.accountSid());
+        }
+        if (isPresent(request.phoneNumber())) {
+            settings.setTwilioPhoneNumber(request.phoneNumber());
+        }
+        organizationSettingsRepository.saveAndFlush(settings);
+
+        if (isPresent(request.authToken())) {
+            twilioCredentialsService.saveAuthToken(organizationId, request.authToken());
+        }
+
+        return getTwilioConfig(organizationId);
     }
 
     private boolean isConfigured(UUID organizationId, OrganizationSettings settings) {

--- a/api/src/main/java/com/nail_art/appointment_book/services/OrganizationService.java
+++ b/api/src/main/java/com/nail_art/appointment_book/services/OrganizationService.java
@@ -5,11 +5,13 @@ import com.nail_art.appointment_book.entities.Organization;
 import com.nail_art.appointment_book.entities.OrganizationSettings;
 import com.nail_art.appointment_book.repositories.OrganizationRepository;
 import com.nail_art.appointment_book.repositories.OrganizationSettingsRepository;
+import com.nail_art.appointment_book.responses.AdminOrganizationSummaryResponse;
 import com.nail_art.appointment_book.responses.OrganizationSettingsResponse;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -23,6 +25,30 @@ public class OrganizationService {
     ) {
         this.organizationRepository = organizationRepository;
         this.organizationSettingsRepository = organizationSettingsRepository;
+    }
+
+    /**
+     * Every salon with its profile, SMS flag, and Twilio-configured status — the
+     * platform-admin "all salons" view. Operates on non-@TenantId config tables,
+     * so it is not tenant-scoped (the admin sees every org by design). One settings
+     * lookup per org; fine at the handful-of-salons scale this serves.
+     */
+    @Transactional(readOnly = true)
+    public List<AdminOrganizationSummaryResponse> listAllSalons() {
+        return organizationRepository.findAll().stream()
+                .map(organization -> {
+                    UUID organizationId = organization.getId();
+                    OrganizationSettings settings = organizationSettingsRepository.findById(organizationId).orElse(null);
+                    return new AdminOrganizationSummaryResponse(
+                            organizationId,
+                            organization.getName(),
+                            organization.getTimezone(),
+                            organization.getBusinessPhone(),
+                            settings != null && settings.isSmsRemindersEnabled(),
+                            isConfigured(organizationId, settings)
+                    );
+                })
+                .toList();
     }
 
     @Transactional(readOnly = true)

--- a/api/src/main/java/com/nail_art/appointment_book/services/UserService.java
+++ b/api/src/main/java/com/nail_art/appointment_book/services/UserService.java
@@ -1,5 +1,6 @@
 package com.nail_art.appointment_book.services;
 
+import com.nail_art.appointment_book.dtos.AdminUserUpdateRequest;
 import com.nail_art.appointment_book.dtos.CreateUserRequest;
 import com.nail_art.appointment_book.entities.Organization;
 import com.nail_art.appointment_book.entities.OrganizationUser;
@@ -8,6 +9,7 @@ import com.nail_art.appointment_book.entities.User;
 import com.nail_art.appointment_book.repositories.OrganizationRepository;
 import com.nail_art.appointment_book.repositories.OrganizationUserRepository;
 import com.nail_art.appointment_book.repositories.UserRepository;
+import com.nail_art.appointment_book.responses.AdminUserSummary;
 import com.nail_art.appointment_book.responses.MeResponse;
 import com.nail_art.appointment_book.security.AuthenticatedPrincipal;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -16,6 +18,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
@@ -104,6 +107,53 @@ public class UserService {
         organizationUserRepository.save(membership);
 
         return savedUser;
+    }
+
+    /** Platform-admin: every user (owner/staff) in a salon, with their role. */
+    @Transactional(readOnly = true)
+    public List<AdminUserSummary> listOrganizationUsers(UUID organizationId) {
+        return organizationUserRepository.findByOrganizationId(organizationId).stream()
+                .map(membership -> {
+                    User user = userRepository.findById(membership.getUserId())
+                            .orElseThrow(() -> new BadCredentialsException("User not found"));
+                    return new AdminUserSummary(user.getId(), user.getUsername(), membership.getRole());
+                })
+                .toList();
+    }
+
+    /**
+     * Platform-admin: change a salon user's username and/or password. Scoped to a
+     * user that belongs to the given org (membership required, else rejected).
+     * Both fields optional — blank/null leaves the value unchanged. A username
+     * collision with a different user throws (→ 409). The password is hashed.
+     */
+    @Transactional
+    public AdminUserSummary updateUserCredentials(UUID organizationId, UUID userId, AdminUserUpdateRequest request) {
+        OrganizationUser membership = organizationUserRepository
+                .findByUserIdAndOrganizationId(userId, organizationId)
+                .orElseThrow(() -> new BadCredentialsException("User is not a member of this organization"));
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BadCredentialsException("User not found"));
+
+        if (request != null && isPresent(request.username())) {
+            String newUsername = request.username().trim();
+            userRepository.findByUsername(newUsername).ifPresent(existing -> {
+                if (!existing.getId().equals(userId)) {
+                    throw new DataIntegrityViolationException("username already exists: " + newUsername);
+                }
+            });
+            user.setUsername(newUsername);
+        }
+        if (request != null && isPresent(request.password())) {
+            user.setPasswordHash(passwordEncoder.encode(request.password()));
+        }
+        userRepository.save(user);
+
+        return new AdminUserSummary(user.getId(), user.getUsername(), membership.getRole());
+    }
+
+    private static boolean isPresent(String value) {
+        return value != null && !value.isBlank();
     }
 
     private String normalizedRole(String role) {

--- a/api/src/main/java/com/nail_art/appointment_book/services/UserService.java
+++ b/api/src/main/java/com/nail_art/appointment_book/services/UserService.java
@@ -42,11 +42,20 @@ public class UserService {
     public MeResponse getMe(AuthenticatedPrincipal principal) {
         User user = userRepository.findById(principal.userId())
                 .orElseThrow(() -> new BadCredentialsException("User not found"));
+
+        // Platform admins are org-less: no role, no organization summary.
+        if (principal.platformAdmin()) {
+            return new MeResponse(
+                    new MeResponse.UserSummary(user.getId(), user.getUsername(), null, true),
+                    null
+            );
+        }
+
         Organization organization = organizationRepository.findById(principal.organizationId())
                 .orElseThrow(() -> new BadCredentialsException("Organization not found"));
 
         return new MeResponse(
-                new MeResponse.UserSummary(user.getId(), user.getUsername(), principal.role()),
+                new MeResponse.UserSummary(user.getId(), user.getUsername(), principal.role(), false),
                 new MeResponse.OrganizationSummary(
                         organization.getId(),
                         organization.getName(),
@@ -79,7 +88,7 @@ public class UserService {
         membership.setRole(role);
         organizationUserRepository.save(membership);
 
-        return new MeResponse.UserSummary(savedUser.getId(), savedUser.getUsername(), role);
+        return new MeResponse.UserSummary(savedUser.getId(), savedUser.getUsername(), role, false);
     }
 
     private String normalizedRole(String role) {

--- a/api/src/main/java/com/nail_art/appointment_book/services/UserService.java
+++ b/api/src/main/java/com/nail_art/appointment_book/services/UserService.java
@@ -14,9 +14,11 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Locale;
 import java.util.Set;
+import java.util.UUID;
 
 @Service
 public class UserService {
@@ -73,22 +75,35 @@ public class UserService {
         String password = requireText(request.password(), "password");
         String role = normalizedRole(request.role());
 
+        User savedUser = createUserInOrganization(principal.organizationId(), username, request.email(), password, role);
+        return new MeResponse.UserSummary(savedUser.getId(), savedUser.getUsername(), role, false);
+    }
+
+    /**
+     * Create a user and its membership in a given org. Shared by the owner-facing
+     * createUser (scoped to the caller's org) and the platform-admin create-salon
+     * flow (provisioning a brand-new org's first owner). Inputs are assumed
+     * validated; the duplicate-username check throws so the caller's transaction
+     * rolls back cleanly.
+     */
+    @Transactional
+    public User createUserInOrganization(UUID organizationId, String username, String email, String rawPassword, String role) {
         userRepository.findByUsername(username).ifPresent(existing -> {
             throw new DataIntegrityViolationException("username already exists: " + username);
         });
 
         User user = new User();
         user.setUsername(username);
-        user.setEmail(request.email());
-        user.setPasswordHash(passwordEncoder.encode(password));
+        user.setEmail(email);
+        user.setPasswordHash(passwordEncoder.encode(rawPassword));
         User savedUser = userRepository.save(user);
 
         OrganizationUser membership = new OrganizationUser();
-        membership.setId(new OrganizationUserId(principal.organizationId(), savedUser.getId()));
+        membership.setId(new OrganizationUserId(organizationId, savedUser.getId()));
         membership.setRole(role);
         organizationUserRepository.save(membership);
 
-        return new MeResponse.UserSummary(savedUser.getId(), savedUser.getUsername(), role, false);
+        return savedUser;
     }
 
     private String normalizedRole(String role) {

--- a/api/src/main/resources/db/migration/V8__add_platform_admin_flag.sql
+++ b/api/src/main/resources/db/migration/V8__add_platform_admin_flag.sql
@@ -1,0 +1,6 @@
+-- Platform super-user capability. A platform admin is a User-level flag, NOT an
+-- org role (the vestigial 'admin' org role was dropped in V6). Platform admins
+-- have no organization_users membership; their authority comes from this flag.
+-- Additive and safe: existing users default to false.
+alter table users
+    add column is_platform_admin boolean not null default false;

--- a/api/src/main/resources/db/migration/V9__unique_organization_name.sql
+++ b/api/src/main/resources/db/migration/V9__unique_organization_name.sql
@@ -1,0 +1,6 @@
+-- Enforce unique organization names. The operator scripts (bootstrap_organization_owner.py,
+-- set_org_twilio.py) and the admin create-salon pre-check all resolve an org by name; a
+-- duplicate name makes those lookups ambiguous. This is the DB backstop behind the
+-- application-level dup-name check in AdminProvisioningService. Case-insensitive so
+-- "Salon" and "salon" can't both exist. Fails loudly if duplicate names already exist.
+create unique index organizations_name_unique on organizations (lower(name));

--- a/api/src/test/java/com/nail_art/appointment_book/controllers/AdminOrganizationIntegrationTest.java
+++ b/api/src/test/java/com/nail_art/appointment_book/controllers/AdminOrganizationIntegrationTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.UUID;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -186,6 +187,71 @@ class AdminOrganizationIntegrationTest extends PostgresIntegrationTest {
                             .header(HttpHeaders.AUTHORIZATION, token)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content("{\"accountSid\":\"x\",\"phoneNumber\":\"y\",\"authToken\":\"z\"}"))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    @Test
+    void adminCreatesSalon_withMarkerServiceAndSettings_andOwnerCanSignIn() throws Exception {
+        String body = mockMvc.perform(post("/admin/organizations")
+                        .header(HttpHeaders.AUTHORIZATION, adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"Fresh Salon\",\"timezone\":\"America/Chicago\","
+                                + "\"ownerUsername\":\"freshowner\",\"ownerPassword\":\"secret-pass\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("Fresh Salon"))
+                .andExpect(jsonPath("$.ownerUsername").value("freshowner"))
+                .andReturn().getResponse().getContentAsString();
+        UUID freshSalonId = UUID.fromString(objectMapper.readTree(body).get("organizationId").asText());
+
+        // Provisioned: an "Unavailable" marker service and a settings row (SMS off).
+        Integer markerCount = jdbcTemplate.queryForObject(
+                "select count(*) from services where organization_id = ? and is_unavailability_marker = true and name = 'Unavailable'",
+                Integer.class, freshSalonId);
+        org.junit.jupiter.api.Assertions.assertEquals(1, markerCount);
+        Boolean smsEnabled = jdbcTemplate.queryForObject(
+                "select sms_reminders_enabled from organization_settings where organization_id = ?",
+                Boolean.class, freshSalonId);
+        org.junit.jupiter.api.Assertions.assertEquals(Boolean.FALSE, smsEnabled);
+
+        // Appears in the admin list (now 3 salons) and the new owner can authenticate.
+        mockMvc.perform(get("/admin/organizations").header(HttpHeaders.AUTHORIZATION, adminToken))
+                .andExpect(jsonPath("$.length()").value(3));
+        mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"username\":\"freshowner\",\"password\":\"secret-pass\"}"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void createSalon_duplicateOrgName_isRejected() throws Exception {
+        mockMvc.perform(post("/admin/organizations")
+                        .header(HttpHeaders.AUTHORIZATION, adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"Salon A\",\"ownerUsername\":\"someone\",\"ownerPassword\":\"secret-pass\"}"))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void createSalon_duplicateOwnerUsername_rollsBackTheNewOrg() throws Exception {
+        mockMvc.perform(post("/admin/organizations")
+                        .header(HttpHeaders.AUTHORIZATION, adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"Rollback Salon\",\"ownerUsername\":\"ownerA\",\"ownerPassword\":\"secret-pass\"}"))
+                .andExpect(status().isConflict());
+
+        Integer orgCount = jdbcTemplate.queryForObject(
+                "select count(*) from organizations where name = 'Rollback Salon'", Integer.class);
+        org.junit.jupiter.api.Assertions.assertEquals(0, orgCount, "the org must not persist when owner creation fails");
+    }
+
+    @Test
+    void ownerAndStaff_areForbiddenFromCreatingSalons() throws Exception {
+        for (String token : new String[]{ownerAToken, staffAToken}) {
+            mockMvc.perform(post("/admin/organizations")
+                            .header(HttpHeaders.AUTHORIZATION, token)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"name\":\"X\",\"ownerUsername\":\"y\",\"ownerPassword\":\"z\"}"))
                     .andExpect(status().isForbidden());
         }
     }

--- a/api/src/test/java/com/nail_art/appointment_book/controllers/AdminOrganizationIntegrationTest.java
+++ b/api/src/test/java/com/nail_art/appointment_book/controllers/AdminOrganizationIntegrationTest.java
@@ -169,13 +169,39 @@ class AdminOrganizationIntegrationTest extends PostgresIntegrationTest {
     void blankToken_preservesStoredToken() throws Exception {
         configureTwilio(salonB, "ACtestsid", "+15555550111", "super-secret-token");
 
-        // Re-send sid/phone with a blank token — must NOT wipe the stored token.
+        // Capture the exact stored ciphertext. pgp_sym_encrypt is randomized, so a
+        // re-encrypt (the bug we guard against) would change these bytes; an untouched
+        // column keeps them identical. This proves preservation, not just "still non-null".
+        String tokenBefore = jdbcTemplate.queryForObject(
+                "select md5(twilio_auth_token::text) from organization_settings where organization_id = ?",
+                String.class, salonB);
+
+        // Re-send sid/phone with a blank token — must NOT wipe or rewrite the stored token.
         mockMvc.perform(put("/admin/organizations/{id}/twilio", salonB)
                         .header(HttpHeaders.AUTHORIZATION, adminToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"accountSid\":\"ACtestsid\",\"phoneNumber\":\"+15555550111\",\"authToken\":\"\"}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.configured").value(true));
+
+        String tokenAfter = jdbcTemplate.queryForObject(
+                "select md5(twilio_auth_token::text) from organization_settings where organization_id = ?",
+                String.class, salonB);
+        org.junit.jupiter.api.Assertions.assertEquals(tokenBefore, tokenAfter,
+                "blank authToken must leave the stored ciphertext byte-for-byte unchanged");
+    }
+
+    @Test
+    void adminToken_isForbiddenFromOwnerGatedSalonEndpoints() throws Exception {
+        // platform_admin authority is not 'owner'/'staff': the admin cannot act on
+        // owner-gated salon endpoints (defense beyond the org-less tenant scope).
+        mockMvc.perform(post("/employees/create").header(HttpHeaders.AUTHORIZATION, adminToken)
+                        .contentType(MediaType.APPLICATION_JSON).content("{\"name\":\"X\",\"color\":\"#abcdef\"}"))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(post("/users").header(HttpHeaders.AUTHORIZATION, adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"username\":\"x\",\"password\":\"secret-pass\",\"role\":\"staff\"}"))
+                .andExpect(status().isForbidden());
     }
 
     @Test

--- a/api/src/test/java/com/nail_art/appointment_book/controllers/AdminOrganizationIntegrationTest.java
+++ b/api/src/test/java/com/nail_art/appointment_book/controllers/AdminOrganizationIntegrationTest.java
@@ -125,6 +125,71 @@ class AdminOrganizationIntegrationTest extends PostgresIntegrationTest {
         }
     }
 
+    private void configureTwilio(UUID salon, String sid, String phone, String token) throws Exception {
+        mockMvc.perform(put("/admin/organizations/{id}/twilio", salon)
+                        .header(HttpHeaders.AUTHORIZATION, adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"accountSid\":\"%s\",\"phoneNumber\":\"%s\",\"authToken\":\"%s\"}"
+                                .formatted(sid, phone, token)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void adminConfiguresTwilio_thenReadsBackWithoutToken() throws Exception {
+        configureTwilio(salonB, "ACtestsid", "+15555550111", "super-secret-token");
+
+        String body = mockMvc.perform(get("/admin/organizations/{id}/twilio", salonB)
+                        .header(HttpHeaders.AUTHORIZATION, adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.configured").value(true))
+                .andExpect(jsonPath("$.accountSid").value("ACtestsid"))
+                .andExpect(jsonPath("$.phoneNumber").value("+15555550111"))
+                .andReturn().getResponse().getContentAsString();
+
+        // R11: the auth token is write-only — never present in any read.
+        org.junit.jupiter.api.Assertions.assertFalse(
+                body.contains("super-secret-token"), "auth token must never be returned");
+    }
+
+    @Test
+    void smsToggle_enableable_onceTwilioConfigured() throws Exception {
+        configureTwilio(salonB, "ACtestsid", "+15555550111", "super-secret-token");
+
+        mockMvc.perform(put("/admin/organizations/{id}", salonB)
+                        .header(HttpHeaders.AUTHORIZATION, adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"smsRemindersEnabled\":true}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.smsRemindersEnabled").value(true))
+                .andExpect(jsonPath("$.twilioConfigured").value(true));
+    }
+
+    @Test
+    void blankToken_preservesStoredToken() throws Exception {
+        configureTwilio(salonB, "ACtestsid", "+15555550111", "super-secret-token");
+
+        // Re-send sid/phone with a blank token — must NOT wipe the stored token.
+        mockMvc.perform(put("/admin/organizations/{id}/twilio", salonB)
+                        .header(HttpHeaders.AUTHORIZATION, adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"accountSid\":\"ACtestsid\",\"phoneNumber\":\"+15555550111\",\"authToken\":\"\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.configured").value(true));
+    }
+
+    @Test
+    void ownerAndStaff_areForbiddenFromTwilioEndpoints() throws Exception {
+        for (String token : new String[]{ownerAToken, staffAToken}) {
+            mockMvc.perform(get("/admin/organizations/{id}/twilio", salonA).header(HttpHeaders.AUTHORIZATION, token))
+                    .andExpect(status().isForbidden());
+            mockMvc.perform(put("/admin/organizations/{id}/twilio", salonA)
+                            .header(HttpHeaders.AUTHORIZATION, token)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"accountSid\":\"x\",\"phoneNumber\":\"y\",\"authToken\":\"z\"}"))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
     @Test
     void orglessAdmin_seesNoTenantOwnedData() throws Exception {
         // Salon A has an employee; the org-less admin (no tenant scope) must see none

--- a/api/src/test/java/com/nail_art/appointment_book/controllers/AdminOrganizationIntegrationTest.java
+++ b/api/src/test/java/com/nail_art/appointment_book/controllers/AdminOrganizationIntegrationTest.java
@@ -50,6 +50,8 @@ class AdminOrganizationIntegrationTest extends PostgresIntegrationTest {
     private String staffAToken;
     private UUID salonA;
     private UUID salonB;
+    private UUID ownerAId;
+    private UUID staffAId;
 
     @BeforeEach
     void setUp() {
@@ -67,10 +69,10 @@ class AdminOrganizationIntegrationTest extends PostgresIntegrationTest {
         adminToken = identitySupport.adminBearer(adminId);
 
         salonA = identitySupport.createOrganization("Salon A");
-        SeededIdentity ownerA = new SeededIdentity(
-                salonA, identitySupport.seedUserInOrganization(salonA, "ownerA", "owner"), "ownerA", "owner");
-        SeededIdentity staffA = new SeededIdentity(
-                salonA, identitySupport.seedUserInOrganization(salonA, "staffA", "staff"), "staffA", "staff");
+        ownerAId = identitySupport.seedUserInOrganization(salonA, "ownerA", "owner");
+        staffAId = identitySupport.seedUserInOrganization(salonA, "staffA", "staff");
+        SeededIdentity ownerA = new SeededIdentity(salonA, ownerAId, "ownerA", "owner");
+        SeededIdentity staffA = new SeededIdentity(salonA, staffAId, "staffA", "staff");
         ownerAToken = identitySupport.bearer(ownerA);
         staffAToken = identitySupport.bearer(staffA);
 
@@ -278,6 +280,78 @@ class AdminOrganizationIntegrationTest extends PostgresIntegrationTest {
                             .header(HttpHeaders.AUTHORIZATION, token)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content("{\"name\":\"X\",\"ownerUsername\":\"y\",\"ownerPassword\":\"z\"}"))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    private void login(String username, String password, org.springframework.test.web.servlet.ResultMatcher expected)
+            throws Exception {
+        mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"username\":\"%s\",\"password\":\"%s\"}".formatted(username, password)))
+                .andExpect(expected);
+    }
+
+    @Test
+    void adminListsSalonUsers() throws Exception {
+        mockMvc.perform(get("/admin/organizations/{id}/users", salonA).header(HttpHeaders.AUTHORIZATION, adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[?(@.username=='ownerA')].role").value("owner"))
+                .andExpect(jsonPath("$[?(@.username=='staffA')].role").value("staff"));
+    }
+
+    @Test
+    void adminChangesPassword_oldFailsNewWorks() throws Exception {
+        mockMvc.perform(put("/admin/organizations/{id}/users/{userId}", salonA, ownerAId)
+                        .header(HttpHeaders.AUTHORIZATION, adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"password\":\"brand-new-pass\"}"))
+                .andExpect(status().isOk());
+
+        login("ownerA", PostgresIdentityTestSupport.TEST_PASSWORD, status().isUnauthorized());
+        login("ownerA", "brand-new-pass", status().isOk());
+    }
+
+    @Test
+    void adminChangesUsername_newUsernameAuthenticates() throws Exception {
+        mockMvc.perform(put("/admin/organizations/{id}/users/{userId}", salonA, ownerAId)
+                        .header(HttpHeaders.AUTHORIZATION, adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"username\":\"owner-renamed\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username").value("owner-renamed"));
+
+        login("owner-renamed", PostgresIdentityTestSupport.TEST_PASSWORD, status().isOk());
+    }
+
+    @Test
+    void changeUsername_toAnExistingUsername_isRejected() throws Exception {
+        mockMvc.perform(put("/admin/organizations/{id}/users/{userId}", salonA, ownerAId)
+                        .header(HttpHeaders.AUTHORIZATION, adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"username\":\"staffA\"}"))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void updateUser_notAMemberOfThatSalon_isRejected() throws Exception {
+        // ownerA belongs to Salon A, not Salon B — editing them via Salon B must fail.
+        mockMvc.perform(put("/admin/organizations/{id}/users/{userId}", salonB, ownerAId)
+                        .header(HttpHeaders.AUTHORIZATION, adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"password\":\"x\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void ownerAndStaff_areForbiddenFromUserManagement() throws Exception {
+        for (String token : new String[]{ownerAToken, staffAToken}) {
+            mockMvc.perform(get("/admin/organizations/{id}/users", salonA).header(HttpHeaders.AUTHORIZATION, token))
+                    .andExpect(status().isForbidden());
+            mockMvc.perform(put("/admin/organizations/{id}/users/{userId}", salonA, staffAId)
+                            .header(HttpHeaders.AUTHORIZATION, token)
+                            .contentType(MediaType.APPLICATION_JSON).content("{\"password\":\"x\"}"))
                     .andExpect(status().isForbidden());
         }
     }

--- a/api/src/test/java/com/nail_art/appointment_book/controllers/AdminOrganizationIntegrationTest.java
+++ b/api/src/test/java/com/nail_art/appointment_book/controllers/AdminOrganizationIntegrationTest.java
@@ -1,0 +1,143 @@
+package com.nail_art.appointment_book.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nail_art.appointment_book.PostgresIntegrationTest;
+import com.nail_art.appointment_book.multitenancy.TenantContext;
+import com.nail_art.appointment_book.support.PostgresIdentityTestSupport;
+import com.nail_art.appointment_book.support.PostgresIdentityTestSupport.SeededIdentity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Platform-admin operator console: list/read/update salons. An org-less admin can
+ * manage any salon's config; owners/staff are locked out; and the admin — having
+ * no tenant scope — sees no tenant-owned data through normal endpoints.
+ */
+class AdminOrganizationIntegrationTest extends PostgresIntegrationTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Value("${security.jwt.secret-key}")
+    private String secretKey;
+
+    private PostgresIdentityTestSupport identitySupport;
+    private String adminToken;
+    private String ownerAToken;
+    private String staffAToken;
+    private UUID salonA;
+    private UUID salonB;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.clear();
+        identitySupport = new PostgresIdentityTestSupport(jdbcTemplate, passwordEncoder, objectMapper, secretKey);
+        jdbcTemplate.update("delete from appointment_services");
+        jdbcTemplate.update("delete from appointments");
+        jdbcTemplate.update("delete from clients");
+        jdbcTemplate.update("delete from services");
+        jdbcTemplate.update("delete from employees");
+        jdbcTemplate.update("delete from organization_settings");
+        identitySupport.resetIdentityTables();
+
+        UUID adminId = identitySupport.seedPlatformAdmin("operator");
+        adminToken = identitySupport.adminBearer(adminId);
+
+        salonA = identitySupport.createOrganization("Salon A");
+        SeededIdentity ownerA = new SeededIdentity(
+                salonA, identitySupport.seedUserInOrganization(salonA, "ownerA", "owner"), "ownerA", "owner");
+        SeededIdentity staffA = new SeededIdentity(
+                salonA, identitySupport.seedUserInOrganization(salonA, "staffA", "staff"), "staffA", "staff");
+        ownerAToken = identitySupport.bearer(ownerA);
+        staffAToken = identitySupport.bearer(staffA);
+
+        salonB = identitySupport.createOrganization("Salon B");
+    }
+
+    @Test
+    void adminListsAllSalons() throws Exception {
+        mockMvc.perform(get("/admin/organizations").header(HttpHeaders.AUTHORIZATION, adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[?(@.name=='Salon A')]").exists())
+                .andExpect(jsonPath("$[?(@.name=='Salon B')]").exists())
+                .andExpect(jsonPath("$[?(@.name=='Salon A')].twilioConfigured").value(false));
+    }
+
+    @Test
+    void adminUpdatesOneSalonProfile_leavingOthersUntouched() throws Exception {
+        mockMvc.perform(put("/admin/organizations/{id}", salonB)
+                        .header(HttpHeaders.AUTHORIZATION, adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"Salon B Renamed\",\"timezone\":\"America/Chicago\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Salon B Renamed"))
+                .andExpect(jsonPath("$.timezone").value("America/Chicago"));
+
+        mockMvc.perform(get("/admin/organizations/{id}", salonA).header(HttpHeaders.AUTHORIZATION, adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Salon A"));
+    }
+
+    @Test
+    void enableSms_withoutTwilio_isRejected() throws Exception {
+        mockMvc.perform(put("/admin/organizations/{id}", salonB)
+                        .header(HttpHeaders.AUTHORIZATION, adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"smsRemindersEnabled\":true}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void ownerAndStaff_areForbiddenFromAdminEndpoints() throws Exception {
+        for (String token : new String[]{ownerAToken, staffAToken}) {
+            mockMvc.perform(get("/admin/organizations").header(HttpHeaders.AUTHORIZATION, token))
+                    .andExpect(status().isForbidden());
+            mockMvc.perform(get("/admin/organizations/{id}", salonA).header(HttpHeaders.AUTHORIZATION, token))
+                    .andExpect(status().isForbidden());
+            mockMvc.perform(put("/admin/organizations/{id}", salonA)
+                            .header(HttpHeaders.AUTHORIZATION, token)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"name\":\"Hijacked\"}"))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    @Test
+    void orglessAdmin_seesNoTenantOwnedData() throws Exception {
+        // Salon A has an employee; the org-less admin (no tenant scope) must see none
+        // through the normal tenant-scoped endpoint — sentinel-empty, never a leak.
+        jdbcTemplate.update(
+                "insert into employees (organization_id, name, color) values (?, ?, ?)",
+                salonA, "Anna", "#111111");
+
+        // /employees/ returns a Page; the org-less admin's tenant scope is the
+        // sentinel, so its content is empty even though Salon A has an employee.
+        mockMvc.perform(get("/employees/").header(HttpHeaders.AUTHORIZATION, adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(0))
+                .andExpect(jsonPath("$.totalElements").value(0));
+    }
+}

--- a/api/src/test/java/com/nail_art/appointment_book/controllers/AppointmentControllerIntegrationTest.java
+++ b/api/src/test/java/com/nail_art/appointment_book/controllers/AppointmentControllerIntegrationTest.java
@@ -57,8 +57,8 @@ class AppointmentControllerIntegrationTest extends PostgresIntegrationTest {
         jdbcTemplate.update("delete from services");
         jdbcTemplate.update("delete from employees");
         identitySupport.resetIdentityTables();
-        ownerA = identitySupport.seedIdentity("owner-a", "owner");
-        ownerB = identitySupport.seedIdentity("owner-b", "owner");
+        ownerA = identitySupport.seedIdentity("owner-a", "owner", "Org A");
+        ownerB = identitySupport.seedIdentity("owner-b", "owner", "Org B");
         employeeA = insertEmployee(ownerA.organizationId(), "Anna");
         employeeB = insertEmployee(ownerB.organizationId(), "Bea");
         serviceA = insertService(ownerA.organizationId(), "Gel Manicure");

--- a/api/src/test/java/com/nail_art/appointment_book/controllers/ClientControllerIntegrationTest.java
+++ b/api/src/test/java/com/nail_art/appointment_book/controllers/ClientControllerIntegrationTest.java
@@ -53,8 +53,8 @@ class ClientControllerIntegrationTest extends PostgresIntegrationTest {
         jdbcTemplate.update("delete from appointments");
         jdbcTemplate.update("delete from clients");
         identitySupport.resetIdentityTables();
-        ownerA = identitySupport.seedIdentity("owner-a", "owner");
-        ownerB = identitySupport.seedIdentity("owner-b", "owner");
+        ownerA = identitySupport.seedIdentity("owner-a", "owner", "Org A");
+        ownerB = identitySupport.seedIdentity("owner-b", "owner", "Org B");
     }
 
     @Test

--- a/api/src/test/java/com/nail_art/appointment_book/controllers/CrossOrgIsolationIntegrationTest.java
+++ b/api/src/test/java/com/nail_art/appointment_book/controllers/CrossOrgIsolationIntegrationTest.java
@@ -61,8 +61,8 @@ class CrossOrgIsolationIntegrationTest extends PostgresIntegrationTest {
         jdbcTemplate.update("delete from services");
         jdbcTemplate.update("delete from employees");
         identitySupport.resetIdentityTables();
-        ownerA = identitySupport.seedIdentity("owner-a", "owner");
-        ownerB = identitySupport.seedIdentity("owner-b", "owner");
+        ownerA = identitySupport.seedIdentity("owner-a", "owner", "Org A");
+        ownerB = identitySupport.seedIdentity("owner-b", "owner", "Org B");
         employeeA = insertEmployee(ownerA.organizationId(), "Anna", "#111111");
         employeeB = insertEmployee(ownerB.organizationId(), "Bea", "#222222");
         serviceA = insertService(ownerA.organizationId(), "Gel Manicure");

--- a/api/src/test/java/com/nail_art/appointment_book/controllers/EmployeeControllerIntegrationTest.java
+++ b/api/src/test/java/com/nail_art/appointment_book/controllers/EmployeeControllerIntegrationTest.java
@@ -53,8 +53,8 @@ class EmployeeControllerIntegrationTest extends PostgresIntegrationTest {
         jdbcTemplate.update("delete from appointments");
         jdbcTemplate.update("delete from employees");
         identitySupport.resetIdentityTables();
-        ownerA = identitySupport.seedIdentity("owner-a", "owner");
-        ownerB = identitySupport.seedIdentity("owner-b", "owner");
+        ownerA = identitySupport.seedIdentity("owner-a", "owner", "Org A");
+        ownerB = identitySupport.seedIdentity("owner-b", "owner", "Org B");
     }
 
     @Test

--- a/api/src/test/java/com/nail_art/appointment_book/controllers/PlatformAdminAuthIntegrationTest.java
+++ b/api/src/test/java/com/nail_art/appointment_book/controllers/PlatformAdminAuthIntegrationTest.java
@@ -1,0 +1,137 @@
+package com.nail_art.appointment_book.controllers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nail_art.appointment_book.PostgresIntegrationTest;
+import com.nail_art.appointment_book.multitenancy.TenantContext;
+import com.nail_art.appointment_book.support.PostgresIdentityTestSupport;
+import com.nail_art.appointment_book.support.PostgresIdentityTestSupport.SeededIdentity;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * The org-less platform-admin authentication path. A platform admin is a User-level
+ * flag (no org membership, no role); login mints a token with no org claim, the auth
+ * filter accepts it without a membership check, and the owner/staff path stays intact.
+ */
+class PlatformAdminAuthIntegrationTest extends PostgresIntegrationTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Value("${security.jwt.secret-key}")
+    private String secretKey;
+
+    private PostgresIdentityTestSupport identitySupport;
+    private UUID adminId;
+    private SeededIdentity owner;
+
+    @BeforeEach
+    void setUp() {
+        TenantContext.clear();
+        identitySupport = new PostgresIdentityTestSupport(jdbcTemplate, passwordEncoder, objectMapper, secretKey);
+        identitySupport.resetIdentityTables();
+        owner = identitySupport.seedIdentity("owner", "owner");
+        adminId = identitySupport.seedPlatformAdmin("operator");
+    }
+
+    private String login(String username) throws Exception {
+        MvcResult result = mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"username\":\"%s\",\"password\":\"%s\"}"
+                                .formatted(username, PostgresIdentityTestSupport.TEST_PASSWORD)))
+                .andExpect(status().isOk())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString()).get("token").asText();
+    }
+
+    @Test
+    void adminLogin_mintsOrglessToken() throws Exception {
+        JsonNode claims = identitySupport.claimsOf(login("operator"));
+
+        assertEquals(adminId.toString(), claims.get("sub").asText());
+        assertTrue(claims.get("admin").asBoolean(), "admin claim must be true");
+        assertFalse(claims.has("org"), "admin token must carry no org claim");
+        assertFalse(claims.has("role"), "admin token must carry no role claim");
+    }
+
+    @Test
+    void adminToken_reachesMe_withOrglessIdentity() throws Exception {
+        mockMvc.perform(get("/users/me").header(HttpHeaders.AUTHORIZATION, identitySupport.adminBearer(adminId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.user.isPlatformAdmin").value(true))
+                .andExpect(jsonPath("$.user.id").value(adminId.toString()))
+                .andExpect(jsonPath("$.organization").doesNotExist());
+    }
+
+    @Test
+    void ownerLogin_andMe_areUnchanged() throws Exception {
+        JsonNode claims = identitySupport.claimsOf(login("owner"));
+        assertEquals("owner", claims.get("role").asText());
+        assertNotNull(claims.get("org"));
+
+        mockMvc.perform(get("/users/me").header(HttpHeaders.AUTHORIZATION, identitySupport.bearer(owner)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.user.isPlatformAdmin").value(false))
+                .andExpect(jsonPath("$.organization.id").value(owner.organizationId().toString()));
+    }
+
+    @Test
+    void adminRefresh_returnsAdminToken() throws Exception {
+        MvcResult loginResult = mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"username\":\"operator\",\"password\":\"%s\"}"
+                                .formatted(PostgresIdentityTestSupport.TEST_PASSWORD)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Cookie refreshCookie = loginResult.getResponse().getCookie("refreshToken");
+        assertNotNull(refreshCookie, "login must set a refresh cookie");
+
+        MvcResult refreshResult = mockMvc.perform(post("/auth/refresh").cookie(refreshCookie))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String refreshed = objectMapper.readTree(refreshResult.getResponse().getContentAsString())
+                .get("token").asText();
+        JsonNode claims = identitySupport.claimsOf(refreshed);
+        assertTrue(claims.get("admin").asBoolean());
+        assertFalse(claims.has("org"));
+    }
+
+    @Test
+    void tokenWithSubjectOnly_isRejected() throws Exception {
+        // A non-admin token missing org/role must be rejected cleanly (no NPE -> 401),
+        // proving the admin branch didn't loosen the org-scoped path.
+        mockMvc.perform(get("/users/me").header(HttpHeaders.AUTHORIZATION, identitySupport.bearerSubjectOnly(adminId)))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/api/src/test/java/com/nail_art/appointment_book/controllers/PlatformAdminAuthIntegrationTest.java
+++ b/api/src/test/java/com/nail_art/appointment_book/controllers/PlatformAdminAuthIntegrationTest.java
@@ -128,6 +128,37 @@ class PlatformAdminAuthIntegrationTest extends PostgresIntegrationTest {
     }
 
     @Test
+    void revokedAdmin_isRejectedDespiteValidToken() throws Exception {
+        String token = identitySupport.adminBearer(adminId);
+        // Access works while the flag is set.
+        mockMvc.perform(get("/users/me").header(HttpHeaders.AUTHORIZATION, token))
+                .andExpect(status().isOk());
+
+        // Revoke the flag; the still-valid token must now be rejected (live re-check).
+        jdbcTemplate.update("update users set is_platform_admin = false where id = ?", adminId);
+
+        mockMvc.perform(get("/users/me").header(HttpHeaders.AUTHORIZATION, token))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void revokedAdmin_cannotRefreshToANewAdminToken() throws Exception {
+        MvcResult loginResult = mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"username\":\"operator\",\"password\":\"%s\"}"
+                                .formatted(PostgresIdentityTestSupport.TEST_PASSWORD)))
+                .andExpect(status().isOk())
+                .andReturn();
+        Cookie refreshCookie = loginResult.getResponse().getCookie("refreshToken");
+        assertNotNull(refreshCookie);
+
+        jdbcTemplate.update("update users set is_platform_admin = false where id = ?", adminId);
+
+        mockMvc.perform(post("/auth/refresh").cookie(refreshCookie))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
     void tokenWithSubjectOnly_isRejected() throws Exception {
         // A non-admin token missing org/role must be rejected cleanly (no NPE -> 401),
         // proving the admin branch didn't loosen the org-scoped path.

--- a/api/src/test/java/com/nail_art/appointment_book/controllers/ServiceControllerIntegrationTest.java
+++ b/api/src/test/java/com/nail_art/appointment_book/controllers/ServiceControllerIntegrationTest.java
@@ -53,8 +53,8 @@ class ServiceControllerIntegrationTest extends PostgresIntegrationTest {
         jdbcTemplate.update("delete from appointments");
         jdbcTemplate.update("delete from services");
         identitySupport.resetIdentityTables();
-        ownerA = identitySupport.seedIdentity("owner-a", "owner");
-        ownerB = identitySupport.seedIdentity("owner-b", "owner");
+        ownerA = identitySupport.seedIdentity("owner-a", "owner", "Org A");
+        ownerB = identitySupport.seedIdentity("owner-b", "owner", "Org B");
     }
 
     @Test

--- a/api/src/test/java/com/nail_art/appointment_book/multitenancy/TenantContextIntegrationTest.java
+++ b/api/src/test/java/com/nail_art/appointment_book/multitenancy/TenantContextIntegrationTest.java
@@ -83,8 +83,8 @@ class TenantContextIntegrationTest extends PostgresIntegrationTest {
         // org A's real user, but a JWT minted with org B's org claim. The membership cross-check
         // (existsByUserIdAndOrganizationId) must reject it before any tenant-scoped query runs —
         // a forged org claim never opens another tenant's scope.
-        SeededIdentity orgA = identitySupport.seedIdentity("owner-a", "owner");
-        SeededIdentity orgB = identitySupport.seedIdentity("owner-b", "owner");
+        SeededIdentity orgA = identitySupport.seedIdentity("owner-a", "owner", "Org A");
+        SeededIdentity orgB = identitySupport.seedIdentity("owner-b", "owner", "Org B");
 
         String forgedToken = "Bearer " + identitySupport.signedToken(
                 orgA.userId(), orgB.organizationId(), orgA.role());

--- a/api/src/test/java/com/nail_art/appointment_book/support/PostgresIdentityTestSupport.java
+++ b/api/src/test/java/com/nail_art/appointment_book/support/PostgresIdentityTestSupport.java
@@ -87,6 +87,56 @@ public class PostgresIdentityTestSupport {
         return userId;
     }
 
+    /**
+     * Seed an org-less platform admin: a user with is_platform_admin=true and NO
+     * organization_users membership. Returns the user id.
+     */
+    public UUID seedPlatformAdmin(String username) {
+        UUID userId = jdbcTemplate.queryForObject(
+                "insert into users (username, email, password_hash, is_platform_admin) values (?, ?, ?, true) returning id",
+                UUID.class,
+                username,
+                username.toLowerCase(Locale.ROOT) + "@example.com",
+                passwordEncoder.encode(TEST_PASSWORD)
+        );
+        assertNotNull(userId);
+        return userId;
+    }
+
+    /** Bearer for an org-less platform admin: sub=userId, admin=true, no org/role. */
+    public String adminBearer(UUID userId) {
+        return "Bearer " + signedAdminToken(userId, 3_600_000L);
+    }
+
+    /** Lenient JWT payload decode — does not assert org/role (admin tokens carry neither). */
+    public JsonNode claimsOf(String jwt) throws Exception {
+        String[] parts = jwt.split("\\.");
+        assertEquals(3, parts.length);
+        return objectMapper.readTree(new String(Base64.getUrlDecoder().decode(parts[1])));
+    }
+
+    /** Bearer carrying only a subject — no org, no role, no admin claim. Should be rejected. */
+    public String bearerSubjectOnly(UUID userId) {
+        return "Bearer " + Jwts.builder()
+                .setSubject(userId.toString())
+                .claim("jti", UUID.randomUUID().toString())
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + 3_600_000L))
+                .signWith(signingKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    private String signedAdminToken(UUID userId, long expirationMillis) {
+        return Jwts.builder()
+                .setSubject(userId.toString())
+                .claim("admin", true)
+                .claim("jti", UUID.randomUUID().toString())
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + expirationMillis))
+                .signWith(signingKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
     public String persistRefreshToken(UUID userId, UUID organizationId, String role) {
         String token = signedToken(userId, organizationId, role, 2_592_000_000L);
         jdbcTemplate.update(

--- a/api/src/test/java/com/nail_art/appointment_book/support/PostgresIdentityTestSupport.java
+++ b/api/src/test/java/com/nail_art/appointment_book/support/PostgresIdentityTestSupport.java
@@ -52,7 +52,13 @@ public class PostgresIdentityTestSupport {
     }
 
     public SeededIdentity seedIdentity(String username, String role) {
-        UUID organizationId = createOrganization(TEST_ORGANIZATION_NAME);
+        return seedIdentity(username, role, TEST_ORGANIZATION_NAME);
+    }
+
+    // Organization names are unique (V9). Tests that seed more than one org in a
+    // single run must pass distinct names through this overload.
+    public SeededIdentity seedIdentity(String username, String role, String organizationName) {
+        UUID organizationId = createOrganization(organizationName);
         UUID userId = seedUserInOrganization(organizationId, username, role);
         return new SeededIdentity(organizationId, userId, username, role);
     }

--- a/client/src/AdminPage/CreateOrganization.tsx
+++ b/client/src/AdminPage/CreateOrganization.tsx
@@ -17,21 +17,11 @@ import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 
 import AnimatedPage from "../components/AnimatedPage";
 import PageHeader from "../components/PageHeader";
-import { SPACING, MAX_CONTENT_WIDTH } from "../constants/design";
+import { SPACING, MAX_CONTENT_WIDTH, TIMEZONES } from "../constants/design";
 import { getHttpStatus } from "../utils/httpError";
 import { formatPhoneInput } from "../utils/phone";
 import { createSalon, type CreateSalonResponse } from "../api/admin";
 import { adminSalonsQueryKey } from "./Organizations";
-
-const TIMEZONES = [
-  "America/New_York",
-  "America/Chicago",
-  "America/Denver",
-  "America/Phoenix",
-  "America/Los_Angeles",
-  "America/Anchorage",
-  "Pacific/Honolulu",
-];
 
 export default function CreateOrganization() {
   const navigate = useNavigate();

--- a/client/src/AdminPage/CreateOrganization.tsx
+++ b/client/src/AdminPage/CreateOrganization.tsx
@@ -1,0 +1,215 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  MenuItem,
+  Paper,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+
+import AnimatedPage from "../components/AnimatedPage";
+import PageHeader from "../components/PageHeader";
+import { SPACING, MAX_CONTENT_WIDTH } from "../constants/design";
+import { getHttpStatus } from "../utils/httpError";
+import { formatPhoneInput } from "../utils/phone";
+import { createSalon, type CreateSalonResponse } from "../api/admin";
+import { adminSalonsQueryKey } from "./Organizations";
+
+const TIMEZONES = [
+  "America/New_York",
+  "America/Chicago",
+  "America/Denver",
+  "America/Phoenix",
+  "America/Los_Angeles",
+  "America/Anchorage",
+  "Pacific/Honolulu",
+];
+
+export default function CreateOrganization() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const [form, setForm] = useState({
+    name: "",
+    timezone: "America/New_York",
+    businessPhone: "",
+    ownerUsername: "",
+    ownerPassword: "",
+  });
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+  const [created, setCreated] = useState<CreateSalonResponse | null>(null);
+
+  const update = (patch: Partial<typeof form>) => setForm((current) => ({ ...current, ...patch }));
+
+  const canSubmit =
+    form.name.trim() && form.ownerUsername.trim() && form.ownerPassword.trim() && !saving;
+
+  const handleSubmit = async () => {
+    setError("");
+    setSaving(true);
+    try {
+      const result = await createSalon({
+        name: form.name.trim(),
+        timezone: form.timezone,
+        businessPhone: form.businessPhone || undefined,
+        ownerUsername: form.ownerUsername.trim(),
+        ownerPassword: form.ownerPassword,
+      });
+      await queryClient.invalidateQueries({ queryKey: adminSalonsQueryKey });
+      setCreated(result);
+    } catch (err) {
+      setError(
+        getHttpStatus(err) === 409
+          ? "That salon name or owner username already exists."
+          : "Could not create the salon. Please check the fields and try again."
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (created) {
+    return (
+      <AnimatedPage>
+        <Box sx={{ p: SPACING.page, maxWidth: MAX_CONTENT_WIDTH, mx: "auto" }}>
+          <Paper variant="outlined" sx={{ p: SPACING.section }}>
+            <Stack spacing={1.5} alignItems="flex-start">
+              <Stack direction="row" spacing={1} alignItems="center">
+                <CheckCircleIcon color="success" />
+                <Typography variant="h6" fontWeight={700}>
+                  {created.name} created
+                </Typography>
+              </Stack>
+              <Typography variant="body2" color="text.secondary">
+                Share these owner credentials with the salon. The password is not stored in plain
+                text and can't be shown again.
+              </Typography>
+              <Box
+                sx={{
+                  width: "100%",
+                  bgcolor: "action.hover",
+                  borderRadius: 1,
+                  p: 2,
+                  fontFamily: "monospace",
+                  fontSize: 14,
+                }}
+              >
+                <div>Owner username: {created.ownerUsername}</div>
+                <div>Owner password: {form.ownerPassword}</div>
+              </Box>
+              <Stack direction="row" spacing={1.5} sx={{ pt: 1 }}>
+                <Button variant="contained" onClick={() => navigate(`/Admin/${created.organizationId}`)}>
+                  Configure Twilio
+                </Button>
+                <Button onClick={() => navigate("/Admin")}>Back to salons</Button>
+              </Stack>
+            </Stack>
+          </Paper>
+        </Box>
+      </AnimatedPage>
+    );
+  }
+
+  return (
+    <AnimatedPage>
+      <Box sx={{ p: SPACING.page, maxWidth: MAX_CONTENT_WIDTH, mx: "auto" }}>
+        <Button startIcon={<ArrowBackIcon />} onClick={() => navigate("/Admin")} sx={{ mb: 1 }}>
+          All salons
+        </Button>
+        <Paper variant="outlined" sx={{ p: SPACING.section }}>
+          <PageHeader title="New salon" subtitle="Create an organization and its first owner login" />
+
+          <Typography variant="subtitle1" fontWeight={700} sx={{ mb: 1.5 }}>
+            Salon
+          </Typography>
+          <Stack spacing={2} sx={{ mb: 3 }}>
+            <TextField
+              label="Salon name"
+              required
+              fullWidth
+              size="small"
+              value={form.name}
+              onChange={(e) => update({ name: e.target.value })}
+            />
+            <TextField
+              label="Business phone"
+              fullWidth
+              size="small"
+              value={form.businessPhone}
+              onChange={(e) => {
+                const next = formatPhoneInput(e.target.value, form.businessPhone);
+                if (next !== null) update({ businessPhone: next });
+              }}
+            />
+            <TextField
+              select
+              label="Timezone"
+              fullWidth
+              size="small"
+              value={form.timezone}
+              onChange={(e) => update({ timezone: e.target.value })}
+            >
+              {TIMEZONES.map((tz) => (
+                <MenuItem key={tz} value={tz}>
+                  {tz}
+                </MenuItem>
+              ))}
+            </TextField>
+          </Stack>
+
+          <Typography variant="subtitle1" fontWeight={700} sx={{ mb: 1.5 }}>
+            First owner login
+          </Typography>
+          <Stack spacing={2}>
+            <TextField
+              label="Owner username"
+              required
+              fullWidth
+              size="small"
+              autoComplete="off"
+              value={form.ownerUsername}
+              onChange={(e) => update({ ownerUsername: e.target.value })}
+            />
+            <TextField
+              label="Owner password"
+              required
+              fullWidth
+              size="small"
+              type="text"
+              autoComplete="off"
+              value={form.ownerPassword}
+              onChange={(e) => update({ ownerPassword: e.target.value })}
+            />
+          </Stack>
+
+          {error && (
+            <Alert severity="error" sx={{ mt: 2 }}>
+              {error}
+            </Alert>
+          )}
+
+          <Box sx={{ mt: 3, display: "flex", justifyContent: "flex-end" }}>
+            <Button
+              variant="contained"
+              onClick={handleSubmit}
+              disabled={!canSubmit}
+              startIcon={saving ? <CircularProgress size={16} color="inherit" /> : undefined}
+              sx={{ minWidth: 140 }}
+            >
+              {saving ? "Creating…" : "Create salon"}
+            </Button>
+          </Box>
+        </Paper>
+      </Box>
+    </AnimatedPage>
+  );
+}

--- a/client/src/AdminPage/CreateOrganization.tsx
+++ b/client/src/AdminPage/CreateOrganization.tsx
@@ -80,8 +80,9 @@ export default function CreateOrganization() {
                 </Typography>
               </Stack>
               <Typography variant="body2" color="text.secondary">
-                Share these owner credentials with the salon. The password is not stored in plain
-                text and can't be shown again.
+                The owner can sign in with the username below and the password you set. The password
+                is hashed and never shown again — if it's lost, reset it from the salon's Users
+                section.
               </Typography>
               <Box
                 sx={{
@@ -94,7 +95,6 @@ export default function CreateOrganization() {
                 }}
               >
                 <div>Owner username: {created.ownerUsername}</div>
-                <div>Owner password: {form.ownerPassword}</div>
               </Box>
               <Stack direction="row" spacing={1.5} sx={{ pt: 1 }}>
                 <Button variant="contained" onClick={() => navigate(`/Admin/${created.organizationId}`)}>

--- a/client/src/AdminPage/OrganizationDetail.tsx
+++ b/client/src/AdminPage/OrganizationDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState, type ReactNode } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
@@ -7,8 +7,8 @@ import {
   Button,
   Chip,
   CircularProgress,
+  Divider,
   FormControlLabel,
-  FormHelperText,
   MenuItem,
   Paper,
   Snackbar,
@@ -18,6 +18,7 @@ import {
   Typography,
 } from "@mui/material";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import EditIcon from "@mui/icons-material/Edit";
 
 import AnimatedPage from "../components/AnimatedPage";
 import PageHeader from "../components/PageHeader";
@@ -28,12 +29,27 @@ import { formatPhoneInput } from "../utils/phone";
 import {
   getSalon,
   getSalonTwilio,
+  listSalonUsers,
   updateSalon,
   updateSalonTwilio,
+  updateSalonUser,
 } from "../api/admin";
 import { adminSalonsQueryKey } from "./Organizations";
 
 type Snack = { msg: string; severity: "success" | "error" };
+
+function ReadRow({ label, value }: { label: string; value: string }) {
+  return (
+    <Box sx={{ display: "flex", justifyContent: "space-between", gap: 2, py: 0.75 }}>
+      <Typography variant="body2" color="text.secondary">
+        {label}
+      </Typography>
+      <Typography variant="body2" sx={{ fontWeight: 500, textAlign: "right", wordBreak: "break-word" }}>
+        {value}
+      </Typography>
+    </Box>
+  );
+}
 
 export default function OrganizationDetail() {
   const { organizationId = "" } = useParams();
@@ -52,42 +68,41 @@ export default function OrganizationDetail() {
     refetchOnWindowFocus: false,
     enabled: Boolean(organizationId),
   });
+  const usersQuery = useQuery({
+    queryKey: ["admin-salon-users", organizationId],
+    queryFn: () => listSalonUsers(organizationId),
+    refetchOnWindowFocus: false,
+    enabled: Boolean(organizationId),
+  });
 
-  const [profile, setProfile] = useState({
+  // Read-first: each section is a display until its Edit button opens a form.
+  const [editingProfile, setEditingProfile] = useState(false);
+  const [editingTwilio, setEditingTwilio] = useState(false);
+  const [editingUserId, setEditingUserId] = useState<string | null>(null);
+
+  const [profileForm, setProfileForm] = useState({
     name: "",
     businessPhone: "",
     timezone: "America/New_York",
     smsRemindersEnabled: false,
   });
-  const [twilio, setTwilio] = useState({ accountSid: "", phoneNumber: "", authToken: "" });
-  const [savingProfile, setSavingProfile] = useState(false);
-  const [savingTwilio, setSavingTwilio] = useState(false);
+  const [twilioForm, setTwilioForm] = useState({ accountSid: "", phoneNumber: "", authToken: "" });
+  const [userForm, setUserForm] = useState({ username: "", password: "" });
+  const [saving, setSaving] = useState(false);
   const [snack, setSnack] = useState<Snack | null>(null);
 
-  useEffect(() => {
-    if (!salonQuery.data) return;
-    setProfile({
-      name: salonQuery.data.name ?? "",
-      businessPhone: salonQuery.data.businessPhone ?? "",
-      timezone: salonQuery.data.timezone ?? "America/New_York",
-      smsRemindersEnabled: salonQuery.data.smsRemindersEnabled,
-    });
-  }, [salonQuery.data]);
-
-  useEffect(() => {
-    if (!twilioQuery.data) return;
-    setTwilio({
-      accountSid: twilioQuery.data.accountSid ?? "",
-      phoneNumber: twilioQuery.data.phoneNumber ?? "",
-      authToken: "",
-    });
-  }, [twilioQuery.data]);
-
-  if (salonQuery.isLoading || twilioQuery.isLoading) {
+  if (salonQuery.isLoading || twilioQuery.isLoading || usersQuery.isLoading) {
     return <PageSkeleton />;
   }
 
-  if (salonQuery.isError || twilioQuery.isError || !salonQuery.data || !twilioQuery.data) {
+  if (
+    salonQuery.isError ||
+    twilioQuery.isError ||
+    usersQuery.isError ||
+    !salonQuery.data ||
+    !twilioQuery.data ||
+    !usersQuery.data
+  ) {
     return (
       <AnimatedPage>
         <Box sx={{ p: SPACING.page, maxWidth: MAX_CONTENT_WIDTH, mx: "auto" }}>
@@ -97,29 +112,54 @@ export default function OrganizationDetail() {
     );
   }
 
-  const twilioConfigured = salonQuery.data.twilioConfigured;
+  const salon = salonQuery.data;
+  const twilio = twilioQuery.data;
+  const users = usersQuery.data;
+  const twilioConfigured = salon.twilioConfigured;
 
-  const invalidate = async () => {
-    await Promise.all([
+  const invalidate = () =>
+    Promise.all([
       queryClient.invalidateQueries({ queryKey: ["admin-salon", organizationId] }),
       queryClient.invalidateQueries({ queryKey: ["admin-salon-twilio", organizationId] }),
+      queryClient.invalidateQueries({ queryKey: ["admin-salon-users", organizationId] }),
       queryClient.invalidateQueries({ queryKey: adminSalonsQueryKey }),
     ]);
+
+  const startEditProfile = () => {
+    setProfileForm({
+      name: salon.name ?? "",
+      businessPhone: salon.businessPhone ?? "",
+      timezone: salon.timezone ?? "America/New_York",
+      smsRemindersEnabled: salon.smsRemindersEnabled,
+    });
+    setEditingProfile(true);
+  };
+
+  const startEditTwilio = () => {
+    setTwilioForm({
+      accountSid: twilio.accountSid ?? "",
+      phoneNumber: twilio.phoneNumber ?? "",
+      authToken: "",
+    });
+    setEditingTwilio(true);
+  };
+
+  const startEditUser = (userId: string, username: string) => {
+    setUserForm({ username, password: "" });
+    setEditingUserId(userId);
   };
 
   const handleSaveProfile = async () => {
-    setSavingProfile(true);
+    setSaving(true);
     try {
-      // Only send the SMS toggle when it's actually controllable (Twilio configured);
-      // otherwise a profile-only edit would re-send a stored `true` and trip the
-      // backend's enable-without-Twilio 400. Mirrors the owner Settings page.
       await updateSalon(organizationId, {
-        name: profile.name,
-        businessPhone: profile.businessPhone,
-        timezone: profile.timezone,
-        ...(twilioConfigured ? { smsRemindersEnabled: profile.smsRemindersEnabled } : {}),
+        name: profileForm.name,
+        businessPhone: profileForm.businessPhone,
+        timezone: profileForm.timezone,
+        ...(twilioConfigured ? { smsRemindersEnabled: profileForm.smsRemindersEnabled } : {}),
       });
       await invalidate();
+      setEditingProfile(false);
       setSnack({ msg: "Profile saved.", severity: "success" });
     } catch (error) {
       setSnack({
@@ -130,32 +170,54 @@ export default function OrganizationDetail() {
         severity: "error",
       });
     } finally {
-      setSavingProfile(false);
+      setSaving(false);
     }
   };
 
   const handleSaveTwilio = async () => {
-    setSavingTwilio(true);
+    setSaving(true);
     try {
       await updateSalonTwilio(organizationId, {
-        accountSid: twilio.accountSid,
-        phoneNumber: twilio.phoneNumber,
-        // Blank token is intentionally sent as empty and treated as "leave unchanged".
-        authToken: twilio.authToken,
+        accountSid: twilioForm.accountSid,
+        phoneNumber: twilioForm.phoneNumber,
+        authToken: twilioForm.authToken, // blank = leave unchanged
       });
-      setTwilio((current) => ({ ...current, authToken: "" }));
       await invalidate();
+      setEditingTwilio(false);
       setSnack({ msg: "Twilio configuration saved.", severity: "success" });
     } catch {
       setSnack({ msg: "Could not save Twilio configuration. Please try again.", severity: "error" });
     } finally {
-      setSavingTwilio(false);
+      setSaving(false);
     }
   };
 
-  const timezoneOptions = TIMEZONES.includes(profile.timezone)
+  const handleSaveUser = async (userId: string) => {
+    setSaving(true);
+    try {
+      await updateSalonUser(organizationId, userId, {
+        username: userForm.username,
+        password: userForm.password, // blank = leave unchanged
+      });
+      await invalidate();
+      setEditingUserId(null);
+      setSnack({ msg: "User updated.", severity: "success" });
+    } catch (error) {
+      setSnack({
+        msg:
+          getHttpStatus(error) === 409
+            ? "That username is already taken."
+            : "Could not update the user. Please try again.",
+        severity: "error",
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const timezoneOptions = TIMEZONES.includes(profileForm.timezone)
     ? TIMEZONES
-    : [profile.timezone, ...TIMEZONES];
+    : [profileForm.timezone, ...TIMEZONES];
 
   return (
     <AnimatedPage>
@@ -164,126 +226,206 @@ export default function OrganizationDetail() {
           All salons
         </Button>
 
+        {/* Profile */}
         <Paper variant="outlined" sx={{ p: SPACING.section, mb: 2 }}>
-          <PageHeader title={salonQuery.data.name} subtitle="Salon profile and SMS reminders" />
+          <PageHeader
+            title={salon.name}
+            subtitle="Salon profile and SMS reminders"
+            action={
+              !editingProfile ? (
+                <Button startIcon={<EditIcon />} onClick={startEditProfile}>
+                  Edit
+                </Button>
+              ) : undefined
+            }
+          />
 
-          <Stack spacing={2} sx={{ mb: 1 }}>
-            <TextField
-              label="Salon name"
-              fullWidth
-              size="small"
-              value={profile.name}
-              onChange={(e) => setProfile((p) => ({ ...p, name: e.target.value }))}
-            />
-            <TextField
-              label="Business phone"
-              fullWidth
-              size="small"
-              value={profile.businessPhone}
-              onChange={(e) => {
-                const next = formatPhoneInput(e.target.value, profile.businessPhone);
-                if (next !== null) setProfile((p) => ({ ...p, businessPhone: next }));
-              }}
-            />
-            <TextField
-              select
-              label="Timezone"
-              fullWidth
-              size="small"
-              value={profile.timezone}
-              onChange={(e) => setProfile((p) => ({ ...p, timezone: e.target.value }))}
-            >
-              {timezoneOptions.map((tz) => (
-                <MenuItem key={tz} value={tz}>
-                  {tz}
-                </MenuItem>
-              ))}
-            </TextField>
-          </Stack>
-
-          <Box sx={{ mt: 1 }}>
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={twilioConfigured && profile.smsRemindersEnabled}
-                  disabled={!twilioConfigured}
-                  onChange={(e) => setProfile((p) => ({ ...p, smsRemindersEnabled: e.target.checked }))}
+          {!editingProfile ? (
+            <Stack divider={<Divider flexItem />}>
+              <ReadRow label="Salon name" value={salon.name} />
+              <ReadRow label="Business phone" value={salon.businessPhone || "—"} />
+              <ReadRow label="Timezone" value={salon.timezone} />
+              <ReadRow
+                label="SMS reminders"
+                value={
+                  !twilioConfigured
+                    ? "Unavailable (Twilio not configured)"
+                    : salon.smsRemindersEnabled
+                      ? "On"
+                      : "Off"
+                }
+              />
+            </Stack>
+          ) : (
+            <>
+              <Stack spacing={2} sx={{ mb: 1 }}>
+                <TextField
+                  label="Salon name"
+                  fullWidth
+                  size="small"
+                  value={profileForm.name}
+                  onChange={(e) => setProfileForm((p) => ({ ...p, name: e.target.value }))}
                 />
-              }
-              label="Send SMS appointment reminders"
-            />
-            {!twilioConfigured && (
-              <FormHelperText>Configure Twilio below before enabling SMS reminders.</FormHelperText>
-            )}
-          </Box>
-
-          <Box sx={{ mt: 3, display: "flex", justifyContent: "flex-end" }}>
-            <Button
-              variant="contained"
-              onClick={handleSaveProfile}
-              disabled={savingProfile}
-              startIcon={savingProfile ? <CircularProgress size={16} color="inherit" /> : undefined}
-              sx={{ minWidth: 120 }}
-            >
-              {savingProfile ? "Saving…" : "Save profile"}
-            </Button>
-          </Box>
+                <TextField
+                  label="Business phone"
+                  fullWidth
+                  size="small"
+                  value={profileForm.businessPhone}
+                  onChange={(e) => {
+                    const next = formatPhoneInput(e.target.value, profileForm.businessPhone);
+                    if (next !== null) setProfileForm((p) => ({ ...p, businessPhone: next }));
+                  }}
+                />
+                <TextField
+                  select
+                  label="Timezone"
+                  fullWidth
+                  size="small"
+                  value={profileForm.timezone}
+                  onChange={(e) => setProfileForm((p) => ({ ...p, timezone: e.target.value }))}
+                >
+                  {timezoneOptions.map((tz) => (
+                    <MenuItem key={tz} value={tz}>
+                      {tz}
+                    </MenuItem>
+                  ))}
+                </TextField>
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={twilioConfigured && profileForm.smsRemindersEnabled}
+                      disabled={!twilioConfigured}
+                      onChange={(e) => setProfileForm((p) => ({ ...p, smsRemindersEnabled: e.target.checked }))}
+                    />
+                  }
+                  label={twilioConfigured ? "Send SMS appointment reminders" : "SMS reminders (configure Twilio first)"}
+                />
+              </Stack>
+              <EditActions
+                saving={saving}
+                onCancel={() => setEditingProfile(false)}
+                onSave={handleSaveProfile}
+              />
+            </>
+          )}
         </Paper>
 
+        {/* Twilio */}
+        <Paper variant="outlined" sx={{ p: SPACING.section, mb: 2 }}>
+          <SectionHeader
+            title="Twilio configuration"
+            chip={
+              <Chip
+                size="small"
+                label={twilioConfigured ? "Configured" : "Not configured"}
+                color={twilioConfigured ? "success" : "default"}
+                variant={twilioConfigured ? "filled" : "outlined"}
+              />
+            }
+            onEdit={!editingTwilio ? startEditTwilio : undefined}
+          />
+
+          {!editingTwilio ? (
+            <Stack divider={<Divider flexItem />}>
+              <ReadRow label="Account SID" value={twilio.accountSid || "—"} />
+              <ReadRow label="Sending phone number" value={twilio.phoneNumber || "—"} />
+              <ReadRow label="Auth token" value={twilioConfigured ? "•••••••• (set)" : "Not set"} />
+            </Stack>
+          ) : (
+            <>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                The auth token is write-only — it's never shown. Leave it blank to keep the current one.
+              </Typography>
+              <Stack spacing={2}>
+                <TextField
+                  label="Account SID"
+                  fullWidth
+                  size="small"
+                  value={twilioForm.accountSid}
+                  onChange={(e) => setTwilioForm((t) => ({ ...t, accountSid: e.target.value }))}
+                />
+                <TextField
+                  label="Sending phone number"
+                  fullWidth
+                  size="small"
+                  value={twilioForm.phoneNumber}
+                  onChange={(e) => setTwilioForm((t) => ({ ...t, phoneNumber: e.target.value }))}
+                />
+                <TextField
+                  label="Auth token"
+                  type="password"
+                  fullWidth
+                  size="small"
+                  value={twilioForm.authToken}
+                  placeholder={twilioConfigured ? "Leave blank to keep current" : "Enter the Twilio auth token"}
+                  onChange={(e) => setTwilioForm((t) => ({ ...t, authToken: e.target.value }))}
+                />
+              </Stack>
+              <EditActions saving={saving} onCancel={() => setEditingTwilio(false)} onSave={handleSaveTwilio} />
+            </>
+          )}
+        </Paper>
+
+        {/* Users */}
         <Paper variant="outlined" sx={{ p: SPACING.section }}>
-          <Stack direction="row" alignItems="center" spacing={1.5} sx={{ mb: 0.5 }}>
-            <Typography variant="subtitle1" fontWeight={700}>
-              Twilio configuration
-            </Typography>
-            <Chip
-              size="small"
-              label={twilioConfigured ? "Configured" : "Not configured"}
-              color={twilioConfigured ? "success" : "default"}
-              variant={twilioConfigured ? "filled" : "outlined"}
-            />
-          </Stack>
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-            This salon sends reminders from its own Twilio account. The auth token is write-only — it
-            is never shown; leave it blank to keep the current one.
+          <Typography variant="subtitle1" fontWeight={700} sx={{ mb: 1.5 }}>
+            Users
           </Typography>
-
-          <Stack spacing={2}>
-            <TextField
-              label="Account SID"
-              fullWidth
-              size="small"
-              value={twilio.accountSid}
-              onChange={(e) => setTwilio((t) => ({ ...t, accountSid: e.target.value }))}
-            />
-            <TextField
-              label="Sending phone number"
-              fullWidth
-              size="small"
-              value={twilio.phoneNumber}
-              onChange={(e) => setTwilio((t) => ({ ...t, phoneNumber: e.target.value }))}
-            />
-            <TextField
-              label="Auth token"
-              type="password"
-              fullWidth
-              size="small"
-              value={twilio.authToken}
-              placeholder={twilioConfigured ? "•••••••• (leave blank to keep current)" : "Enter the Twilio auth token"}
-              onChange={(e) => setTwilio((t) => ({ ...t, authToken: e.target.value }))}
-            />
+          <Stack divider={<Divider flexItem />}>
+            {users.map((user) => (
+              <Box key={user.id} sx={{ py: 1 }}>
+                {editingUserId !== user.id ? (
+                  <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
+                    <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+                      <Typography fontWeight={500} noWrap>
+                        {user.username}
+                      </Typography>
+                      <Typography variant="body2" color="text.secondary">
+                        {user.role}
+                      </Typography>
+                    </Box>
+                    <Button
+                      size="small"
+                      startIcon={<EditIcon />}
+                      disabled={editingUserId !== null}
+                      onClick={() => startEditUser(user.id, user.username)}
+                    >
+                      Edit
+                    </Button>
+                  </Box>
+                ) : (
+                  <Stack spacing={2} sx={{ py: 1 }}>
+                    <Typography variant="body2" color="text.secondary">
+                      Editing {user.role} login
+                    </Typography>
+                    <TextField
+                      label="Username"
+                      fullWidth
+                      size="small"
+                      autoComplete="off"
+                      value={userForm.username}
+                      onChange={(e) => setUserForm((u) => ({ ...u, username: e.target.value }))}
+                    />
+                    <TextField
+                      label="New password"
+                      type="password"
+                      fullWidth
+                      size="small"
+                      autoComplete="new-password"
+                      placeholder="Leave blank to keep current"
+                      value={userForm.password}
+                      onChange={(e) => setUserForm((u) => ({ ...u, password: e.target.value }))}
+                    />
+                    <EditActions
+                      saving={saving}
+                      onCancel={() => setEditingUserId(null)}
+                      onSave={() => handleSaveUser(user.id)}
+                    />
+                  </Stack>
+                )}
+              </Box>
+            ))}
           </Stack>
-
-          <Box sx={{ mt: 3, display: "flex", justifyContent: "flex-end" }}>
-            <Button
-              variant="contained"
-              onClick={handleSaveTwilio}
-              disabled={savingTwilio}
-              startIcon={savingTwilio ? <CircularProgress size={16} color="inherit" /> : undefined}
-              sx={{ minWidth: 120 }}
-            >
-              {savingTwilio ? "Saving…" : "Save Twilio"}
-            </Button>
-          </Box>
         </Paper>
       </Box>
       <Snackbar
@@ -299,5 +441,57 @@ export default function OrganizationDetail() {
         ) : undefined}
       </Snackbar>
     </AnimatedPage>
+  );
+}
+
+function SectionHeader({
+  title,
+  chip,
+  onEdit,
+}: {
+  title: string;
+  chip?: ReactNode;
+  onEdit?: () => void;
+}) {
+  return (
+    <Stack direction="row" alignItems="center" sx={{ mb: 1.5 }}>
+      <Typography variant="subtitle1" fontWeight={700}>
+        {title}
+      </Typography>
+      {chip && <Box sx={{ ml: 1.5 }}>{chip}</Box>}
+      <Box sx={{ flexGrow: 1 }} />
+      {onEdit && (
+        <Button startIcon={<EditIcon />} onClick={onEdit}>
+          Edit
+        </Button>
+      )}
+    </Stack>
+  );
+}
+
+function EditActions({
+  saving,
+  onCancel,
+  onSave,
+}: {
+  saving: boolean;
+  onCancel: () => void;
+  onSave: () => void;
+}) {
+  return (
+    <Box sx={{ mt: 3, display: "flex", justifyContent: "flex-end", gap: 1 }}>
+      <Button onClick={onCancel} disabled={saving}>
+        Cancel
+      </Button>
+      <Button
+        variant="contained"
+        onClick={onSave}
+        disabled={saving}
+        startIcon={saving ? <CircularProgress size={16} color="inherit" /> : undefined}
+        sx={{ minWidth: 100 }}
+      >
+        {saving ? "Saving…" : "Save"}
+      </Button>
+    </Box>
   );
 }

--- a/client/src/AdminPage/OrganizationDetail.tsx
+++ b/client/src/AdminPage/OrganizationDetail.tsx
@@ -22,7 +22,7 @@ import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import AnimatedPage from "../components/AnimatedPage";
 import PageHeader from "../components/PageHeader";
 import PageSkeleton from "../components/PageSkeleton";
-import { SPACING, MAX_CONTENT_WIDTH } from "../constants/design";
+import { SPACING, MAX_CONTENT_WIDTH, TIMEZONES } from "../constants/design";
 import { getHttpStatus } from "../utils/httpError";
 import { formatPhoneInput } from "../utils/phone";
 import {
@@ -32,16 +32,6 @@ import {
   updateSalonTwilio,
 } from "../api/admin";
 import { adminSalonsQueryKey } from "./Organizations";
-
-const TIMEZONES = [
-  "America/New_York",
-  "America/Chicago",
-  "America/Denver",
-  "America/Phoenix",
-  "America/Los_Angeles",
-  "America/Anchorage",
-  "Pacific/Honolulu",
-];
 
 type Snack = { msg: string; severity: "success" | "error" };
 

--- a/client/src/AdminPage/OrganizationDetail.tsx
+++ b/client/src/AdminPage/OrganizationDetail.tsx
@@ -87,7 +87,7 @@ export default function OrganizationDetail() {
     return <PageSkeleton />;
   }
 
-  if (salonQuery.isError || !salonQuery.data || !twilioQuery.data) {
+  if (salonQuery.isError || twilioQuery.isError || !salonQuery.data || !twilioQuery.data) {
     return (
       <AnimatedPage>
         <Box sx={{ p: SPACING.page, maxWidth: MAX_CONTENT_WIDTH, mx: "auto" }}>
@@ -110,11 +110,14 @@ export default function OrganizationDetail() {
   const handleSaveProfile = async () => {
     setSavingProfile(true);
     try {
+      // Only send the SMS toggle when it's actually controllable (Twilio configured);
+      // otherwise a profile-only edit would re-send a stored `true` and trip the
+      // backend's enable-without-Twilio 400. Mirrors the owner Settings page.
       await updateSalon(organizationId, {
         name: profile.name,
         businessPhone: profile.businessPhone,
         timezone: profile.timezone,
-        smsRemindersEnabled: profile.smsRemindersEnabled,
+        ...(twilioConfigured ? { smsRemindersEnabled: profile.smsRemindersEnabled } : {}),
       });
       await invalidate();
       setSnack({ msg: "Profile saved.", severity: "success" });

--- a/client/src/AdminPage/OrganizationDetail.tsx
+++ b/client/src/AdminPage/OrganizationDetail.tsx
@@ -1,0 +1,310 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  FormControlLabel,
+  FormHelperText,
+  MenuItem,
+  Paper,
+  Snackbar,
+  Stack,
+  Switch,
+  TextField,
+  Typography,
+} from "@mui/material";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+
+import AnimatedPage from "../components/AnimatedPage";
+import PageHeader from "../components/PageHeader";
+import PageSkeleton from "../components/PageSkeleton";
+import { SPACING, MAX_CONTENT_WIDTH } from "../constants/design";
+import { getHttpStatus } from "../utils/httpError";
+import { formatPhoneInput } from "../utils/phone";
+import {
+  getSalon,
+  getSalonTwilio,
+  updateSalon,
+  updateSalonTwilio,
+} from "../api/admin";
+import { adminSalonsQueryKey } from "./Organizations";
+
+const TIMEZONES = [
+  "America/New_York",
+  "America/Chicago",
+  "America/Denver",
+  "America/Phoenix",
+  "America/Los_Angeles",
+  "America/Anchorage",
+  "Pacific/Honolulu",
+];
+
+type Snack = { msg: string; severity: "success" | "error" };
+
+export default function OrganizationDetail() {
+  const { organizationId = "" } = useParams();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const salonQuery = useQuery({
+    queryKey: ["admin-salon", organizationId],
+    queryFn: () => getSalon(organizationId),
+    refetchOnWindowFocus: false,
+    enabled: Boolean(organizationId),
+  });
+  const twilioQuery = useQuery({
+    queryKey: ["admin-salon-twilio", organizationId],
+    queryFn: () => getSalonTwilio(organizationId),
+    refetchOnWindowFocus: false,
+    enabled: Boolean(organizationId),
+  });
+
+  const [profile, setProfile] = useState({
+    name: "",
+    businessPhone: "",
+    timezone: "America/New_York",
+    smsRemindersEnabled: false,
+  });
+  const [twilio, setTwilio] = useState({ accountSid: "", phoneNumber: "", authToken: "" });
+  const [savingProfile, setSavingProfile] = useState(false);
+  const [savingTwilio, setSavingTwilio] = useState(false);
+  const [snack, setSnack] = useState<Snack | null>(null);
+
+  useEffect(() => {
+    if (!salonQuery.data) return;
+    setProfile({
+      name: salonQuery.data.name ?? "",
+      businessPhone: salonQuery.data.businessPhone ?? "",
+      timezone: salonQuery.data.timezone ?? "America/New_York",
+      smsRemindersEnabled: salonQuery.data.smsRemindersEnabled,
+    });
+  }, [salonQuery.data]);
+
+  useEffect(() => {
+    if (!twilioQuery.data) return;
+    setTwilio({
+      accountSid: twilioQuery.data.accountSid ?? "",
+      phoneNumber: twilioQuery.data.phoneNumber ?? "",
+      authToken: "",
+    });
+  }, [twilioQuery.data]);
+
+  if (salonQuery.isLoading || twilioQuery.isLoading) {
+    return <PageSkeleton />;
+  }
+
+  if (salonQuery.isError || !salonQuery.data || !twilioQuery.data) {
+    return (
+      <AnimatedPage>
+        <Box sx={{ p: SPACING.page, maxWidth: MAX_CONTENT_WIDTH, mx: "auto" }}>
+          <Alert severity="error">Could not load this salon. Check your connection and refresh.</Alert>
+        </Box>
+      </AnimatedPage>
+    );
+  }
+
+  const twilioConfigured = salonQuery.data.twilioConfigured;
+
+  const invalidate = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ["admin-salon", organizationId] }),
+      queryClient.invalidateQueries({ queryKey: ["admin-salon-twilio", organizationId] }),
+      queryClient.invalidateQueries({ queryKey: adminSalonsQueryKey }),
+    ]);
+  };
+
+  const handleSaveProfile = async () => {
+    setSavingProfile(true);
+    try {
+      await updateSalon(organizationId, {
+        name: profile.name,
+        businessPhone: profile.businessPhone,
+        timezone: profile.timezone,
+        smsRemindersEnabled: profile.smsRemindersEnabled,
+      });
+      await invalidate();
+      setSnack({ msg: "Profile saved.", severity: "success" });
+    } catch (error) {
+      setSnack({
+        msg:
+          getHttpStatus(error) === 400
+            ? "SMS reminders can't be enabled until Twilio is fully configured."
+            : "Could not save the profile. Please try again.",
+        severity: "error",
+      });
+    } finally {
+      setSavingProfile(false);
+    }
+  };
+
+  const handleSaveTwilio = async () => {
+    setSavingTwilio(true);
+    try {
+      await updateSalonTwilio(organizationId, {
+        accountSid: twilio.accountSid,
+        phoneNumber: twilio.phoneNumber,
+        // Blank token is intentionally sent as empty and treated as "leave unchanged".
+        authToken: twilio.authToken,
+      });
+      setTwilio((current) => ({ ...current, authToken: "" }));
+      await invalidate();
+      setSnack({ msg: "Twilio configuration saved.", severity: "success" });
+    } catch {
+      setSnack({ msg: "Could not save Twilio configuration. Please try again.", severity: "error" });
+    } finally {
+      setSavingTwilio(false);
+    }
+  };
+
+  const timezoneOptions = TIMEZONES.includes(profile.timezone)
+    ? TIMEZONES
+    : [profile.timezone, ...TIMEZONES];
+
+  return (
+    <AnimatedPage>
+      <Box sx={{ p: SPACING.page, maxWidth: MAX_CONTENT_WIDTH, mx: "auto" }}>
+        <Button startIcon={<ArrowBackIcon />} onClick={() => navigate("/Admin")} sx={{ mb: 1 }}>
+          All salons
+        </Button>
+
+        <Paper variant="outlined" sx={{ p: SPACING.section, mb: 2 }}>
+          <PageHeader title={salonQuery.data.name} subtitle="Salon profile and SMS reminders" />
+
+          <Stack spacing={2} sx={{ mb: 1 }}>
+            <TextField
+              label="Salon name"
+              fullWidth
+              size="small"
+              value={profile.name}
+              onChange={(e) => setProfile((p) => ({ ...p, name: e.target.value }))}
+            />
+            <TextField
+              label="Business phone"
+              fullWidth
+              size="small"
+              value={profile.businessPhone}
+              onChange={(e) => {
+                const next = formatPhoneInput(e.target.value, profile.businessPhone);
+                if (next !== null) setProfile((p) => ({ ...p, businessPhone: next }));
+              }}
+            />
+            <TextField
+              select
+              label="Timezone"
+              fullWidth
+              size="small"
+              value={profile.timezone}
+              onChange={(e) => setProfile((p) => ({ ...p, timezone: e.target.value }))}
+            >
+              {timezoneOptions.map((tz) => (
+                <MenuItem key={tz} value={tz}>
+                  {tz}
+                </MenuItem>
+              ))}
+            </TextField>
+          </Stack>
+
+          <Box sx={{ mt: 1 }}>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={twilioConfigured && profile.smsRemindersEnabled}
+                  disabled={!twilioConfigured}
+                  onChange={(e) => setProfile((p) => ({ ...p, smsRemindersEnabled: e.target.checked }))}
+                />
+              }
+              label="Send SMS appointment reminders"
+            />
+            {!twilioConfigured && (
+              <FormHelperText>Configure Twilio below before enabling SMS reminders.</FormHelperText>
+            )}
+          </Box>
+
+          <Box sx={{ mt: 3, display: "flex", justifyContent: "flex-end" }}>
+            <Button
+              variant="contained"
+              onClick={handleSaveProfile}
+              disabled={savingProfile}
+              startIcon={savingProfile ? <CircularProgress size={16} color="inherit" /> : undefined}
+              sx={{ minWidth: 120 }}
+            >
+              {savingProfile ? "Saving…" : "Save profile"}
+            </Button>
+          </Box>
+        </Paper>
+
+        <Paper variant="outlined" sx={{ p: SPACING.section }}>
+          <Stack direction="row" alignItems="center" spacing={1.5} sx={{ mb: 0.5 }}>
+            <Typography variant="subtitle1" fontWeight={700}>
+              Twilio configuration
+            </Typography>
+            <Chip
+              size="small"
+              label={twilioConfigured ? "Configured" : "Not configured"}
+              color={twilioConfigured ? "success" : "default"}
+              variant={twilioConfigured ? "filled" : "outlined"}
+            />
+          </Stack>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            This salon sends reminders from its own Twilio account. The auth token is write-only — it
+            is never shown; leave it blank to keep the current one.
+          </Typography>
+
+          <Stack spacing={2}>
+            <TextField
+              label="Account SID"
+              fullWidth
+              size="small"
+              value={twilio.accountSid}
+              onChange={(e) => setTwilio((t) => ({ ...t, accountSid: e.target.value }))}
+            />
+            <TextField
+              label="Sending phone number"
+              fullWidth
+              size="small"
+              value={twilio.phoneNumber}
+              onChange={(e) => setTwilio((t) => ({ ...t, phoneNumber: e.target.value }))}
+            />
+            <TextField
+              label="Auth token"
+              type="password"
+              fullWidth
+              size="small"
+              value={twilio.authToken}
+              placeholder={twilioConfigured ? "•••••••• (leave blank to keep current)" : "Enter the Twilio auth token"}
+              onChange={(e) => setTwilio((t) => ({ ...t, authToken: e.target.value }))}
+            />
+          </Stack>
+
+          <Box sx={{ mt: 3, display: "flex", justifyContent: "flex-end" }}>
+            <Button
+              variant="contained"
+              onClick={handleSaveTwilio}
+              disabled={savingTwilio}
+              startIcon={savingTwilio ? <CircularProgress size={16} color="inherit" /> : undefined}
+              sx={{ minWidth: 120 }}
+            >
+              {savingTwilio ? "Saving…" : "Save Twilio"}
+            </Button>
+          </Box>
+        </Paper>
+      </Box>
+      <Snackbar
+        open={Boolean(snack)}
+        autoHideDuration={5000}
+        onClose={() => setSnack(null)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+      >
+        {snack ? (
+          <Alert severity={snack.severity} variant="filled" onClose={() => setSnack(null)}>
+            {snack.msg}
+          </Alert>
+        ) : undefined}
+      </Snackbar>
+    </AnimatedPage>
+  );
+}

--- a/client/src/AdminPage/Organizations.tsx
+++ b/client/src/AdminPage/Organizations.tsx
@@ -1,0 +1,106 @@
+import { useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  Paper,
+  Stack,
+  Typography,
+} from "@mui/material";
+import AddIcon from "@mui/icons-material/Add";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+
+import AnimatedPage from "../components/AnimatedPage";
+import PageHeader from "../components/PageHeader";
+import PageSkeleton from "../components/PageSkeleton";
+import { SPACING, MAX_CONTENT_WIDTH } from "../constants/design";
+import { listSalons } from "../api/admin";
+
+export const adminSalonsQueryKey = ["admin-salons"] as const;
+
+export default function Organizations() {
+  const navigate = useNavigate();
+  const { data, isLoading, isError } = useQuery({
+    queryKey: adminSalonsQueryKey,
+    queryFn: listSalons,
+    refetchOnWindowFocus: false,
+  });
+
+  if (isLoading) {
+    return <PageSkeleton />;
+  }
+
+  return (
+    <AnimatedPage>
+      <Box sx={{ p: SPACING.page, maxWidth: MAX_CONTENT_WIDTH, mx: "auto" }}>
+        <PageHeader
+          title="Salons"
+          subtitle="Manage every organization, its profile, and its Twilio configuration"
+          action={
+            <Button
+              variant="contained"
+              startIcon={<AddIcon />}
+              onClick={() => navigate("/Admin/new")}
+            >
+              New salon
+            </Button>
+          }
+        />
+
+        {isError || !data ? (
+          <Alert severity="error">Could not load salons. Check your connection and refresh.</Alert>
+        ) : data.length === 0 ? (
+          <Paper variant="outlined" sx={{ p: SPACING.section, textAlign: "center" }}>
+            <Typography color="text.secondary">No salons yet. Create the first one.</Typography>
+          </Paper>
+        ) : (
+          <Stack spacing={1.5}>
+            {data.map((salon) => (
+              <Paper
+                key={salon.id}
+                variant="outlined"
+                onClick={() => navigate(`/Admin/${salon.id}`)}
+                sx={{
+                  p: SPACING.card,
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 2,
+                  cursor: "pointer",
+                  transition: "background-color 120ms",
+                  "&:hover": { backgroundColor: "action.hover" },
+                }}
+              >
+                <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+                  <Typography fontWeight={700} noWrap>
+                    {salon.name}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary" noWrap>
+                    {salon.timezone}
+                    {salon.businessPhone ? ` · ${salon.businessPhone}` : ""}
+                  </Typography>
+                </Box>
+                <Stack direction="row" spacing={1} sx={{ flexShrink: 0 }}>
+                  <Chip
+                    size="small"
+                    label={salon.twilioConfigured ? "Twilio set" : "No Twilio"}
+                    color={salon.twilioConfigured ? "success" : "default"}
+                    variant={salon.twilioConfigured ? "filled" : "outlined"}
+                  />
+                  <Chip
+                    size="small"
+                    label={salon.smsRemindersEnabled ? "SMS on" : "SMS off"}
+                    color={salon.smsRemindersEnabled ? "primary" : "default"}
+                    variant={salon.smsRemindersEnabled ? "filled" : "outlined"}
+                  />
+                </Stack>
+                <ChevronRightIcon sx={{ color: "text.disabled", flexShrink: 0 }} />
+              </Paper>
+            ))}
+          </Stack>
+        )}
+      </Box>
+    </AnimatedPage>
+  );
+}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,9 @@ import MobileBottomNav from "./Navbar/MobileBottomNav.tsx";
 import Search from "./AppointmentsPage/Search/Search.tsx";
 import Clients from "./ClientsPage/Clients.tsx";
 import Settings from "./SettingsPage/Settings.tsx";
+import AdminOrganizations from "./AdminPage/Organizations.tsx";
+import AdminOrganizationDetail from "./AdminPage/OrganizationDetail.tsx";
+import AdminCreateOrganization from "./AdminPage/CreateOrganization.tsx";
 import { RequireMe } from "./components/RequireMe";
 import {
   BrowserRouter as Router,
@@ -79,6 +82,30 @@ function AppContent() {
             element={
               <RequireMe requiredRole="owner">
                 <Settings />
+              </RequireMe>
+            }
+          />
+          <Route
+            path="/Admin"
+            element={
+              <RequireMe requirePlatformAdmin>
+                <AdminOrganizations />
+              </RequireMe>
+            }
+          />
+          <Route
+            path="/Admin/new"
+            element={
+              <RequireMe requirePlatformAdmin>
+                <AdminCreateOrganization />
+              </RequireMe>
+            }
+          />
+          <Route
+            path="/Admin/:organizationId"
+            element={
+              <RequireMe requirePlatformAdmin>
+                <AdminOrganizationDetail />
               </RequireMe>
             }
           />

--- a/client/src/AppointmentsPage/Calendar/Calendar.tsx
+++ b/client/src/AppointmentsPage/Calendar/Calendar.tsx
@@ -12,7 +12,7 @@ const CalendarClient = () => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down(MOBILE_BREAKPOINT));
   const { data: me } = useMe();
-  const orgTz = me?.organization.timezone;
+  const orgTz = me?.organization?.timezone;
   const [startDate, setStartDate] = useState(
     localStorage.getItem("startDate")
       ? dayjs(localStorage.getItem("startDate"))

--- a/client/src/AppointmentsPage/Search/Search.tsx
+++ b/client/src/AppointmentsPage/Search/Search.tsx
@@ -41,7 +41,7 @@ export default function Search() {
     showedUp: false,
   });
   const { data: me, isLoading: meLoading } = useMe();
-  const orgTz = me?.organization.timezone;
+  const orgTz = me?.organization?.timezone;
 
   const {
     data: employees,

--- a/client/src/Login/Login.tsx
+++ b/client/src/Login/Login.tsx
@@ -36,9 +36,14 @@ export default function Login() {
       const previousUrl = localStorage.getItem("previousUrl");
       setIsLoading(true);
       await login(username, password);
-      await queryClient.prefetchQuery({ queryKey: meQueryKey, queryFn: fetchMe });
+      const me = await queryClient.fetchQuery({ queryKey: meQueryKey, queryFn: fetchMe });
       setIsLoading(false);
-      if (previousUrl) {
+      // Platform admins are org-less and belong in the operator console, never on
+      // a salon page (or a stale previousUrl pointing at one).
+      if (me.user.isPlatformAdmin) {
+        localStorage.removeItem("previousUrl");
+        navigate("/Admin");
+      } else if (previousUrl) {
         navigate(previousUrl);
         localStorage.removeItem("previousUrl");
       } else {

--- a/client/src/Navbar/MoreDrawer.tsx
+++ b/client/src/Navbar/MoreDrawer.tsx
@@ -10,6 +10,7 @@ import { Link } from "react-router-dom";
 import BadgeIcon from "@mui/icons-material/Badge";
 import ContentCutIcon from "@mui/icons-material/ContentCut";
 import SettingsIcon from "@mui/icons-material/Settings";
+import StorefrontIcon from "@mui/icons-material/Storefront";
 import LoginIcon from "@mui/icons-material/Login";
 import LogoutIcon from "@mui/icons-material/Logout";
 import { logout } from "../api/auth/auth";
@@ -31,9 +32,11 @@ export default function MoreDrawer({
 }) {
   const isLoggedIn = Boolean(localStorage.getItem("token"));
   const { data: me } = useMe();
-  // Settings is owner-only; staff never see the entry.
-  const moreItems =
-    me?.user.role === "owner"
+  // Platform admins are org-less: only the operator console. Otherwise Settings
+  // is owner-only; staff never see the entry.
+  const moreItems = me?.user.isPlatformAdmin
+    ? [{ title: "Salons", url: "/Admin", icon: <StorefrontIcon /> }]
+    : me?.user.role === "owner"
       ? [...baseItems, { title: "Settings", url: "/Settings", icon: <SettingsIcon /> }]
       : baseItems;
 

--- a/client/src/Navbar/Navbar.tsx
+++ b/client/src/Navbar/Navbar.tsx
@@ -39,9 +39,11 @@ function Navbar() {
   const location = useLocation();
   const { data: me } = useMe();
 
-  // Settings is owner-only; staff never see the entry.
-  const items =
-    me?.user.role === "owner"
+  // Platform admins are org-less: they see only the operator console, never the
+  // salon nav. Otherwise Settings is owner-only; staff never see the entry.
+  const items = me?.user.isPlatformAdmin
+    ? [{ title: "Salons", url: "/Admin" }]
+    : me?.user.role === "owner"
       ? [...navItems, { title: "Settings", url: "/Settings" }]
       : navItems;
 

--- a/client/src/SettingsPage/Settings.tsx
+++ b/client/src/SettingsPage/Settings.tsx
@@ -20,7 +20,7 @@ import {
 import AnimatedPage from "../components/AnimatedPage";
 import PageHeader from "../components/PageHeader";
 import PageSkeleton from "../components/PageSkeleton";
-import { SPACING, MAX_CONTENT_WIDTH } from "../constants/design";
+import { SPACING, MAX_CONTENT_WIDTH, TIMEZONES } from "../constants/design";
 import {
   getOrganizationSettings,
   updateOrganizationSettings,
@@ -28,16 +28,6 @@ import {
 } from "../api/organization";
 import { getHttpStatus } from "../utils/httpError";
 import { formatPhoneInput } from "../utils/phone";
-
-const TIMEZONES = [
-  "America/New_York",
-  "America/Chicago",
-  "America/Denver",
-  "America/Phoenix",
-  "America/Los_Angeles",
-  "America/Anchorage",
-  "Pacific/Honolulu",
-];
 
 type FormState = {
   name: string;

--- a/client/src/api/admin/admin.ts
+++ b/client/src/api/admin/admin.ts
@@ -1,0 +1,93 @@
+import api from "../api";
+
+// One salon row in the operator console list.
+export type AdminSalonSummary = {
+  id: string;
+  name: string;
+  timezone: string;
+  businessPhone: string | null;
+  smsRemindersEnabled: boolean;
+  twilioConfigured: boolean;
+};
+
+// A salon's profile + SMS view (same shape the owner Settings endpoint returns).
+export type AdminSalonSettings = {
+  name: string;
+  businessPhone: string | null;
+  timezone: string;
+  smsRemindersEnabled: boolean;
+  twilioConfigured: boolean;
+};
+
+// Every field optional: omit one to leave the stored value untouched.
+export type AdminSalonUpdate = {
+  name?: string;
+  businessPhone?: string;
+  timezone?: string;
+  smsRemindersEnabled?: boolean;
+};
+
+// Twilio config read. The auth token is write-only and never returned.
+export type AdminTwilioConfig = {
+  configured: boolean;
+  accountSid: string | null;
+  phoneNumber: string | null;
+};
+
+// SID/phone set when non-blank; authToken set when non-blank, else left untouched.
+export type AdminTwilioUpdate = {
+  accountSid?: string;
+  phoneNumber?: string;
+  authToken?: string;
+};
+
+export type CreateSalonRequest = {
+  name: string;
+  timezone?: string;
+  businessPhone?: string;
+  ownerUsername: string;
+  ownerPassword: string;
+};
+
+export type CreateSalonResponse = {
+  organizationId: string;
+  name: string;
+  ownerUserId: string;
+  ownerUsername: string;
+};
+
+export const listSalons = async (): Promise<AdminSalonSummary[]> => {
+  const response = await api.get<AdminSalonSummary[]>("/admin/organizations");
+  return response.data;
+};
+
+export const getSalon = async (organizationId: string): Promise<AdminSalonSettings> => {
+  const response = await api.get<AdminSalonSettings>(`/admin/organizations/${organizationId}`);
+  return response.data;
+};
+
+export const updateSalon = async (
+  organizationId: string,
+  update: AdminSalonUpdate
+): Promise<AdminSalonSettings> => {
+  const response = await api.put<AdminSalonSettings>(`/admin/organizations/${organizationId}`, update);
+  return response.data;
+};
+
+export const getSalonTwilio = async (organizationId: string): Promise<AdminTwilioConfig> => {
+  const response = await api.get<AdminTwilioConfig>(`/admin/organizations/${organizationId}/twilio`);
+  return response.data;
+};
+
+export const updateSalonTwilio = async (
+  organizationId: string,
+  update: AdminTwilioUpdate
+): Promise<AdminTwilioConfig> => {
+  const response = await api.put<AdminTwilioConfig>(`/admin/organizations/${organizationId}/twilio`, update);
+  return response.data;
+};
+
+export const createSalon = async (request: CreateSalonRequest): Promise<CreateSalonResponse> => {
+  const response = await api.post<CreateSalonResponse>("/admin/organizations", request);
+  return response.data;
+};

--- a/client/src/api/admin/admin.ts
+++ b/client/src/api/admin/admin.ts
@@ -91,3 +91,32 @@ export const createSalon = async (request: CreateSalonRequest): Promise<CreateSa
   const response = await api.post<CreateSalonResponse>("/admin/organizations", request);
   return response.data;
 };
+
+export type AdminSalonUser = {
+  id: string;
+  username: string;
+  role: string;
+};
+
+// Both optional: omit/blank to leave unchanged. Password is write-only.
+export type AdminUserUpdate = {
+  username?: string;
+  password?: string;
+};
+
+export const listSalonUsers = async (organizationId: string): Promise<AdminSalonUser[]> => {
+  const response = await api.get<AdminSalonUser[]>(`/admin/organizations/${organizationId}/users`);
+  return response.data;
+};
+
+export const updateSalonUser = async (
+  organizationId: string,
+  userId: string,
+  update: AdminUserUpdate
+): Promise<AdminSalonUser> => {
+  const response = await api.put<AdminSalonUser>(
+    `/admin/organizations/${organizationId}/users/${userId}`,
+    update
+  );
+  return response.data;
+};

--- a/client/src/api/admin/index.ts
+++ b/client/src/api/admin/index.ts
@@ -1,0 +1,1 @@
+export * from "./admin";

--- a/client/src/api/me/me.ts
+++ b/client/src/api/me/me.ts
@@ -4,14 +4,17 @@ export type MeResponse = {
   user: {
     id: string;
     username: string;
-    role: string;
+    // null for a platform admin (org-less); a role string for owners/staff.
+    role: string | null;
+    isPlatformAdmin: boolean;
   };
+  // null for a platform admin (no organization); always present for owners/staff.
   organization: {
     id: string;
     name: string;
     timezone: string;
     businessPhone: string;
-  };
+  } | null;
 };
 
 export const fetchMe = async (): Promise<MeResponse> => {

--- a/client/src/components/RequireMe.test.tsx
+++ b/client/src/components/RequireMe.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+
+import { RequireMe } from "./RequireMe";
+import { useMe } from "../hooks/useMe";
+import type { MeResponse } from "../api/me/me";
+
+vi.mock("../hooks/useMe", () => ({ useMe: vi.fn() }));
+vi.mock("react-router-dom", () => ({
+  Navigate: ({ to }: { to: string }) => <div data-testid="navigate">{to}</div>,
+}));
+
+const admin: MeResponse = {
+  user: { id: "a", username: "operator", role: null, isPlatformAdmin: true },
+  organization: null,
+};
+const owner: MeResponse = {
+  user: { id: "o", username: "owner", role: "owner", isPlatformAdmin: false },
+  organization: { id: "org", name: "Salon", timezone: "America/New_York", businessPhone: "555" },
+};
+
+function asLoaded(data: MeResponse) {
+  vi.mocked(useMe).mockReturnValue({
+    data,
+    error: null,
+    isError: false,
+    isLoading: false,
+    isPending: false,
+    refetch: vi.fn(),
+  } as unknown as ReturnType<typeof useMe>);
+}
+
+function child() {
+  return <div data-testid="child">protected</div>;
+}
+
+afterEach(() => vi.clearAllMocks());
+
+describe("RequireMe platform-admin gating", () => {
+  it("renders an admin-only route for a platform admin", () => {
+    asLoaded(admin);
+    render(<RequireMe requirePlatformAdmin>{child()}</RequireMe>);
+    expect(screen.getByTestId("child")).toBeInTheDocument();
+  });
+
+  it("redirects a non-admin away from an admin-only route", () => {
+    asLoaded(owner);
+    render(<RequireMe requirePlatformAdmin>{child()}</RequireMe>);
+    expect(screen.getByTestId("navigate")).toHaveTextContent("/Appointments");
+    expect(screen.queryByTestId("child")).not.toBeInTheDocument();
+  });
+
+  it("redirects a platform admin off a salon route to the console", () => {
+    asLoaded(admin);
+    render(<RequireMe>{child()}</RequireMe>);
+    expect(screen.getByTestId("navigate")).toHaveTextContent("/Admin");
+  });
+
+  it("renders a salon route for an owner", () => {
+    asLoaded(owner);
+    render(<RequireMe>{child()}</RequireMe>);
+    expect(screen.getByTestId("child")).toBeInTheDocument();
+  });
+
+  it("still enforces requiredRole for non-admin users", () => {
+    asLoaded({ ...owner, user: { ...owner.user, role: "staff" } });
+    render(
+      <RequireMe requiredRole="owner">
+        {child()}
+      </RequireMe>
+    );
+    expect(screen.getByTestId("navigate")).toHaveTextContent("/Appointments");
+  });
+});

--- a/client/src/components/RequireMe.tsx
+++ b/client/src/components/RequireMe.tsx
@@ -12,6 +12,10 @@ type RequireMeProps = {
   // When set, the route also requires this role; a mismatch redirects to
   // `redirectTo`. Omitting it preserves the plain authenticated-only behavior.
   requiredRole?: string;
+  // When true, the route requires a platform admin (the org-less operator). When
+  // false/omitted, platform admins are redirected to /Admin — salon pages can't
+  // function without an org, so admins are corralled into the console.
+  requirePlatformAdmin?: boolean;
   redirectTo?: string;
 };
 
@@ -19,7 +23,12 @@ type RetryFallbackProps = {
   onRetry: () => void;
 };
 
-export function RequireMe({ children, requiredRole, redirectTo = "/Appointments" }: RequireMeProps) {
+export function RequireMe({
+  children,
+  requiredRole,
+  requirePlatformAdmin,
+  redirectTo = "/Appointments",
+}: RequireMeProps) {
   const { data, error, isError, isLoading, isPending, refetch } = useMe();
 
   if (isLoading || isPending) {
@@ -34,11 +43,24 @@ export function RequireMe({ children, requiredRole, redirectTo = "/Appointments"
     if (!data) {
       return <RetryFallback onRetry={() => void refetch()} />;
     }
-    // fall through to the role check below, using cached data
+    // fall through to the gate checks below, using cached data
   }
 
   if (!data) {
     return <CircularLoading />;
+  }
+
+  if (requirePlatformAdmin) {
+    // Admin-only route: non-admins go back to their salon home.
+    if (!data.user.isPlatformAdmin) {
+      return <Navigate to={redirectTo} replace />;
+    }
+    return <>{children}</>;
+  }
+
+  // Salon route: a platform admin has no org and can't use it — send to the console.
+  if (data.user.isPlatformAdmin) {
+    return <Navigate to="/Admin" replace />;
   }
 
   if (requiredRole && data.user.role !== requiredRole) {

--- a/client/src/constants/design.ts
+++ b/client/src/constants/design.ts
@@ -18,3 +18,14 @@ export const SPACING = {
 } as const;
 
 export const MAX_CONTENT_WIDTH = 1200;
+
+// Supported salon timezones, offered wherever an org timezone is edited.
+export const TIMEZONES: string[] = [
+  "America/New_York",
+  "America/Chicago",
+  "America/Denver",
+  "America/Phoenix",
+  "America/Los_Angeles",
+  "America/Anchorage",
+  "Pacific/Honolulu",
+];

--- a/client/src/hooks/useMe.test.tsx
+++ b/client/src/hooks/useMe.test.tsx
@@ -18,6 +18,7 @@ const meResponse: MeResponse = {
     id: "11111111-1111-4111-8111-111111111111",
     username: "owner",
     role: "owner",
+    isPlatformAdmin: false,
   },
   organization: {
     id: "22222222-2222-4222-8222-222222222222",

--- a/scripts/bootstrap_platform_admin.py
+++ b/scripts/bootstrap_platform_admin.py
@@ -1,0 +1,82 @@
+import argparse
+import os
+import sys
+
+import bcrypt
+import psycopg
+from psycopg import errors
+
+
+class BootstrapError(Exception):
+    pass
+
+
+def postgres_url(cli_url: str | None) -> str:
+    url = cli_url or os.getenv("POSTGRES_URL")
+    if not url:
+        raise BootstrapError("POSTGRES_URL is required or pass --db-url")
+    if url.startswith("jdbc:postgresql://"):
+        return url.removeprefix("jdbc:")
+    return url
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Create the first platform-admin user. A platform admin is org-less "
+            "(no organization_users membership, no role); its authority comes from "
+            "the is_platform_admin flag. Use this to bootstrap the operator console."
+        )
+    )
+    parser.add_argument("--db-url", default=None, help="Postgres URL; defaults to POSTGRES_URL")
+    parser.add_argument("--username", required=True)
+    parser.add_argument("--password", required=True)
+    return parser.parse_args()
+
+
+def create_platform_admin(db_url: str, username: str, password: str) -> str:
+    password_hash = bcrypt.hashpw(
+        password.encode("utf-8"), bcrypt.gensalt(rounds=10)
+    ).decode("utf-8")
+
+    conn = psycopg.connect(db_url)
+    try:
+        with conn.transaction():
+            with conn.cursor() as cur:
+                cur.execute("select id from users where username = %s", (username,))
+                if cur.fetchone() is not None:
+                    raise BootstrapError(f"username already exists: {username}")
+
+                cur.execute(
+                    """
+                    insert into users (username, password_hash, is_platform_admin)
+                    values (%s, %s, true)
+                    returning id
+                    """,
+                    (username, password_hash),
+                )
+                return str(cur.fetchone()[0])
+    except errors.UniqueViolation as exc:
+        raise BootstrapError(f"username already exists: {username}") from exc
+    finally:
+        conn.close()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        user_id = create_platform_admin(
+            postgres_url(args.db_url),
+            args.username,
+            args.password,
+        )
+    except BootstrapError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(f"Created platform admin {args.username} with id {user_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bootstrap_platform_admin.py
+++ b/scripts/bootstrap_platform_admin.py
@@ -5,7 +5,10 @@ import sys
 import bcrypt
 import psycopg
 from psycopg import errors
+from dotenv import load_dotenv
 
+
+load_dotenv()
 
 class BootstrapError(Exception):
     pass

--- a/scripts/bootstrap_platform_admin.py
+++ b/scripts/bootstrap_platform_admin.py
@@ -31,10 +31,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--db-url", default=None, help="Postgres URL; defaults to POSTGRES_URL")
     parser.add_argument("--username", required=True)
     parser.add_argument("--password", required=True)
+    parser.add_argument("--email", default=None, help="Optional contact email for the admin account")
     return parser.parse_args()
 
 
-def create_platform_admin(db_url: str, username: str, password: str) -> str:
+def create_platform_admin(db_url: str, username: str, password: str, email: str | None) -> str:
     password_hash = bcrypt.hashpw(
         password.encode("utf-8"), bcrypt.gensalt(rounds=10)
     ).decode("utf-8")
@@ -49,11 +50,11 @@ def create_platform_admin(db_url: str, username: str, password: str) -> str:
 
                 cur.execute(
                     """
-                    insert into users (username, password_hash, is_platform_admin)
-                    values (%s, %s, true)
+                    insert into users (username, email, password_hash, is_platform_admin)
+                    values (%s, %s, %s, true)
                     returning id
                     """,
-                    (username, password_hash),
+                    (username, email, password_hash),
                 )
                 return str(cur.fetchone()[0])
     except errors.UniqueViolation as exc:
@@ -69,6 +70,7 @@ def main() -> int:
             postgres_url(args.db_url),
             args.username,
             args.password,
+            args.email,
         )
     except BootstrapError as exc:
         print(str(exc), file=sys.stderr)


### PR DESCRIPTION
## Summary

Adds an **org-less platform-admin operator console** — a single operator can list all salons, edit any salon's profile + SMS toggle, set any salon's Twilio credentials, manage a salon's user logins (username/password), and create a new salon with its first owner, entirely in-app. This retires the `create_organization.py` / `bootstrap_organization_owner.py` / `set_org_twilio.py` + psql runbook for routine onboarding and realizes the platform super-user the V6 migration anticipated.

Origin requirements + plan: `docs/brainstorms/2026-05-30-platform-admin-operator-console-requirements.md`, `docs/plans/2026-05-30-001-feat-platform-admin-operator-console-plan.md`.

## What's included

**Identity & auth (org-less admin)**
- `is_platform_admin` flag on `users` (V8), seeded out-of-band by `scripts/bootstrap_platform_admin.py`.
- Login/refresh/filter branch on the flag: admin token carries `admin:true` with **no `org`/`role`**, skips the membership check, opens **no tenant scope**, and carries the `platform_admin` authority. The live flag is re-checked per request (revocation is immediate). Owner/staff auth is unchanged.

**Admin surface (`/admin/organizations`, `platform_admin`-gated)**
- List all salons; read/update any salon's profile + SMS toggle (reuses a generalized `OrganizationService`).
- Set per-salon Twilio config — auth token encrypted via the existing pgcrypto plumbing and **write-only** (never read back; blank token preserves the stored one).
- **Manage salon users:** list a salon's owner/staff logins and change a user's username and/or password (membership-scoped; blank = unchanged; username uniqueness → 409; password hashed + write-only). Closes the lost-owner-password recovery gap.
- Create salon + first owner in one transaction (org + settings + "Unavailable" marker + owner + membership), reusing `UserService` for hashing/duplicate guards.
- `organizations.name` is now unique (V9), backing the by-name lookups the operator scripts rely on.

**Frontend**
- `MeResponse` is org-optional with `isPlatformAdmin`; `RequireMe` gains a `requirePlatformAdmin` gate and corrals admins to `/Admin` (and non-admins out). Login routes admins to the console; nav shows only the console for an admin session.
- Admin pages mirror the existing Settings patterns. The salon-detail page is **read-first**: profile, Twilio, and each user render as a display with an **Edit** button that opens a form with Save/Cancel.
- Create-salon **does not echo the owner password** back (it's hashed; recover via the Users section if lost) — no plaintext-on-screen.

## Testing

- Backend full suite green (`./mvnw test -Dtest="com.nail_art.appointment_book.**"`), incl. `PlatformAdminAuthIntegrationTest` (org-less login, refresh, **revoked-admin rejection** on filter + refresh) and `AdminOrganizationIntegrationTest` (20 cases: list/edit/Twilio write-only with byte-level preservation, SMS gate, create-salon rollback, **user list + password/username change + uniqueness 409 + member-scoping**, owner/staff 403 everywhere, admin 403 on owner-gated routes, org-less admin sees empty tenant data).
- Frontend: `tsc -b --noEmit` clean, `eslint` 0 errors, 44 Vitest tests pass (incl. `RequireMe` gating).
- Reviewed via multi-agent code review (10 personas). **Security found no exploitable issues**; safe fixes auto-applied, security-critical test gaps closed, and the org-name unique index added in response.

## Known Residuals (reviewed, accepted)

Non-exploitable, recorded for follow-up:
- **adv-1 (P2):** a `platform_admin` token can still *reach* tenant-owned endpoints server-side. Reads return sentinel-empty (UUIDs can't collide with the sentinel → provably no leak), writes FK-500; the UI never goes there. Defense-in-depth would block them outright.
- **M-01 (P2):** `OrganizationService` now serves owner + admin concerns; could extract an `AdminOrganizationService`.
- **Quality (P2/P3):** admin React query keys could live in a shared module; `AdminTwilioConfig.configured` is fetched but unused; admin endpoints return 401 (not 404) for an unknown org id or non-member user (pre-existing `BadCredentialsException` pattern).

## Post-Deploy Monitoring & Validation

- **Migrations (V8, V9):** additive. V8 `ADD COLUMN ... NOT NULL DEFAULT false` is metadata-only on PG16 (no rewrite). V9 unique index **fails loudly if duplicate org names already exist** — confirm the existing salon(s) have distinct names before/at deploy; if Flyway fails on V9, dedupe names and re-run.
- **Healthy signals:** owner/staff login + `/users/me` unchanged (org populated); platform admin can log in and reach `/admin/organizations`; owners/staff get 403 on `/admin/**`.
- **Failure signals / triggers:** spike in 401s on `/users/me` (auth-branch regression), 500s on `/admin/**` (admin DB flag re-check or create-salon tx), or Flyway migration failure on boot → roll back the deploy.
- **Validation window:** verify the first admin login + one salon Twilio edit + one user password reset immediately post-deploy; watch the 15:00 ET reminder cron the next day to confirm per-org sends still work. Owner: repo owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
