### PR TITLE
Fix lowercase routes and blank appointment search

### DIFF
--- a/client/src/AdminPage/CreateOrganization.tsx
+++ b/client/src/AdminPage/CreateOrganization.tsx
@@ -18,6 +18,7 @@ import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import AnimatedPage from "../components/AnimatedPage";
 import PageHeader from "../components/PageHeader";
 import { SPACING, MAX_CONTENT_WIDTH, TIMEZONES } from "../constants/design";
+import { ROUTES, adminOrganizationPath } from "../constants/routes";
 import { getHttpStatus } from "../utils/httpError";
 import { formatPhoneInput } from "../utils/phone";
 import { createSalon, type CreateSalonResponse } from "../api/admin";
@@ -97,10 +98,10 @@ export default function CreateOrganization() {
                 <div>Owner username: {created.ownerUsername}</div>
               </Box>
               <Stack direction="row" spacing={1.5} sx={{ pt: 1 }}>
-                <Button variant="contained" onClick={() => navigate(`/Admin/${created.organizationId}`)}>
+                <Button variant="contained" onClick={() => navigate(adminOrganizationPath(created.organizationId))}>
                   Configure Twilio
                 </Button>
-                <Button onClick={() => navigate("/Admin")}>Back to salons</Button>
+                <Button onClick={() => navigate(ROUTES.admin)}>Back to salons</Button>
               </Stack>
             </Stack>
           </Paper>
@@ -112,7 +113,7 @@ export default function CreateOrganization() {
   return (
     <AnimatedPage>
       <Box sx={{ p: SPACING.page, maxWidth: MAX_CONTENT_WIDTH, mx: "auto" }}>
-        <Button startIcon={<ArrowBackIcon />} onClick={() => navigate("/Admin")} sx={{ mb: 1 }}>
+        <Button startIcon={<ArrowBackIcon />} onClick={() => navigate(ROUTES.admin)} sx={{ mb: 1 }}>
           All salons
         </Button>
         <Paper variant="outlined" sx={{ p: SPACING.section }}>

--- a/client/src/AdminPage/OrganizationDetail.tsx
+++ b/client/src/AdminPage/OrganizationDetail.tsx
@@ -26,6 +26,7 @@ import PageSkeleton from "../components/PageSkeleton";
 import { SPACING, MAX_CONTENT_WIDTH, TIMEZONES } from "../constants/design";
 import { getHttpStatus } from "../utils/httpError";
 import { formatPhoneInput } from "../utils/phone";
+import { ROUTES } from "../constants/routes";
 import {
   getSalon,
   getSalonTwilio,
@@ -222,7 +223,7 @@ export default function OrganizationDetail() {
   return (
     <AnimatedPage>
       <Box sx={{ p: SPACING.page, maxWidth: MAX_CONTENT_WIDTH, mx: "auto" }}>
-        <Button startIcon={<ArrowBackIcon />} onClick={() => navigate("/Admin")} sx={{ mb: 1 }}>
+        <Button startIcon={<ArrowBackIcon />} onClick={() => navigate(ROUTES.admin)} sx={{ mb: 1 }}>
           All salons
         </Button>
 

--- a/client/src/AdminPage/Organizations.tsx
+++ b/client/src/AdminPage/Organizations.tsx
@@ -16,6 +16,7 @@ import AnimatedPage from "../components/AnimatedPage";
 import PageHeader from "../components/PageHeader";
 import PageSkeleton from "../components/PageSkeleton";
 import { SPACING, MAX_CONTENT_WIDTH } from "../constants/design";
+import { ROUTES, adminOrganizationPath } from "../constants/routes";
 import { listSalons } from "../api/admin";
 
 export const adminSalonsQueryKey = ["admin-salons"] as const;
@@ -42,7 +43,7 @@ export default function Organizations() {
             <Button
               variant="contained"
               startIcon={<AddIcon />}
-              onClick={() => navigate("/Admin/new")}
+              onClick={() => navigate(ROUTES.adminNew)}
             >
               New salon
             </Button>
@@ -61,7 +62,7 @@ export default function Organizations() {
               <Paper
                 key={salon.id}
                 variant="outlined"
-                onClick={() => navigate(`/Admin/${salon.id}`)}
+                onClick={() => navigate(adminOrganizationPath(salon.id))}
                 sx={{
                   p: SPACING.card,
                   display: "flex",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -20,6 +20,7 @@ import {
 } from "react-router-dom";
 import { Box, useMediaQuery, useTheme } from "@mui/material";
 import { MOBILE_BREAKPOINT } from "./constants/design";
+import { ROUTES } from "./constants/routes";
 
 function AppContent() {
   const theme = useTheme();
@@ -28,16 +29,16 @@ function AppContent() {
   // The login page is the only unauthenticated route. Hiding the nav there keeps
   // its useMe() lookups from firing without a token, which would 401 -> redirect
   // to /login -> remount -> loop.
-  const showChrome = location.pathname.toLowerCase() !== "/login";
+  const showChrome = location.pathname.toLowerCase() !== ROUTES.login;
 
   return (
     <>
       {showChrome && <Navbar />}
       <Box sx={{ pb: isMobile && showChrome ? "72px" : 0 }}>
         <Routes>
-          <Route path="/" element={<Navigate to="/Appointments" replace />} />
+          <Route path={ROUTES.home} element={<Navigate to={ROUTES.appointments} replace />} />
           <Route
-            path="/Appointments"
+            path={ROUTES.appointments}
             element={
               <RequireMe>
                 <Calendar />
@@ -45,16 +46,16 @@ function AppContent() {
             }
           />
           <Route
-            path="/Clients"
+            path={ROUTES.clients}
             element={
               <RequireMe>
                 <Clients />
               </RequireMe>
             }
           />
-          <Route path="/Login" element={<Login />} />
+          <Route path={ROUTES.login} element={<Login />} />
           <Route
-            path="/Employees"
+            path={ROUTES.employees}
             element={
               <RequireMe>
                 <Employees />
@@ -62,7 +63,7 @@ function AppContent() {
             }
           />
           <Route
-            path="/Services"
+            path={ROUTES.services}
             element={
               <RequireMe>
                 <Services />
@@ -70,7 +71,7 @@ function AppContent() {
             }
           />
           <Route
-            path="/Appointments/Search"
+            path={ROUTES.appointmentsSearch}
             element={
               <RequireMe>
                 <Search />
@@ -78,7 +79,7 @@ function AppContent() {
             }
           />
           <Route
-            path="/Settings"
+            path={ROUTES.settings}
             element={
               <RequireMe requiredRole="owner">
                 <Settings />
@@ -86,7 +87,7 @@ function AppContent() {
             }
           />
           <Route
-            path="/Admin"
+            path={ROUTES.admin}
             element={
               <RequireMe requirePlatformAdmin>
                 <AdminOrganizations />
@@ -94,7 +95,7 @@ function AppContent() {
             }
           />
           <Route
-            path="/Admin/new"
+            path={ROUTES.adminNew}
             element={
               <RequireMe requirePlatformAdmin>
                 <AdminCreateOrganization />
@@ -102,7 +103,7 @@ function AppContent() {
             }
           />
           <Route
-            path="/Admin/:organizationId"
+            path={ROUTES.adminOrganization}
             element={
               <RequireMe requirePlatformAdmin>
                 <AdminOrganizationDetail />

--- a/client/src/AppointmentsPage/Calendar/components/CustomCalendar/ContextMenu.tsx
+++ b/client/src/AppointmentsPage/Calendar/components/CustomCalendar/ContextMenu.tsx
@@ -13,6 +13,7 @@ import EventIcon from "@mui/icons-material/Event";
 import { Appointment, Service } from "../../../../types";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { appointmentsSearchPath } from "../../../../constants/routes";
 
 export default function ContextMenu({
   onClose,
@@ -56,7 +57,7 @@ export default function ContextMenu({
     if (!appointment) return;
     setIsLoading(true);
     onClose(e);
-    nav(`/Appointments/Search?pn=${appointment.phoneNumber}`);
+    nav(appointmentsSearchPath(appointment.phoneNumber));
     setIsLoading(false);
   };
   const unavailabilityService = services.find((service) => service.isUnavailabilityMarker);

--- a/client/src/AppointmentsPage/Calendar/components/MobileCalendar.tsx
+++ b/client/src/AppointmentsPage/Calendar/components/MobileCalendar.tsx
@@ -26,6 +26,7 @@ import {
 } from "../../../api/appointments";
 import { getAllServices } from "../../../api/services";
 import { getClients } from "../../../api/clients";
+import { appointmentsSearchPath } from "../../../constants/routes";
 import { Appointment, Employee, Service } from "../../../types";
 import CircularLoading from "../../../components/CircularLoading";
 import EmployeeSelector from "./EmployeeSelector";
@@ -492,7 +493,7 @@ export default function MobileCalendar({
                   variant="outlined"
                   onClick={() => {
                     setDetailApp(null);
-                    navigate(`/Appointments/Search?pn=${detailApp.phoneNumber}`);
+                    navigate(appointmentsSearchPath(detailApp.phoneNumber));
                   }}
                   sx={{ px: 1 }}
                 />

--- a/client/src/AppointmentsPage/Search/Search.tsx
+++ b/client/src/AppointmentsPage/Search/Search.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useCallback } from "react";
 import { Box, TextField, Chip, Button } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
 import { useQuery } from "@tanstack/react-query";
@@ -43,6 +43,26 @@ export default function Search() {
   const { data: me, isLoading: meLoading } = useMe();
   const orgTz = me?.organization?.timezone;
 
+  const runSearch = useCallback(async (rawPhoneNumber: string) => {
+    const normalizedPhoneNumber = rawPhoneNumber.trim();
+    if (!normalizedPhoneNumber) {
+      setTempData([]);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const appointmentsData = await getAppointmentsByPhoneNumber(
+        normalizedPhoneNumber
+      );
+      setTempData(appointmentsData);
+    } catch (error) {
+      console.error("Error fetching appointments:", error);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
   const {
     data: employees,
     isLoading: employeesLoading,
@@ -62,24 +82,9 @@ export default function Search() {
   });
 
   useEffect(() => {
-    const fetchAppointments = async () => {
-      if (phoneNumberParam && phoneNumberParam.trim() !== "") {
-        setLoading(true);
-        try {
-          const appointmentsData = await getAppointmentsByPhoneNumber(
-            phoneNumberParam
-          );
-          setTempData(appointmentsData);
-        } catch (error) {
-          console.error("Error fetching appointments:", error);
-        } finally {
-          setLoading(false);
-        }
-      }
-    };
-
-    fetchAppointments();
-  }, [phoneNumberParam]);
+    setPhoneNumber(phoneNumberParam);
+    void runSearch(phoneNumberParam);
+  }, [phoneNumberParam, runSearch]);
 
   function changePhoneNumber(inputPhoneNumber: string) {
     const regex = /^\d{0,3}[\s-]?\d{0,3}[\s-]?\d{0,4}$/;
@@ -97,17 +102,7 @@ export default function Search() {
 
   const handleKeyDown = async (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (event.key === "Enter") {
-      setLoading(true);
-      try {
-        const appointmentsData = await getAppointmentsByPhoneNumber(
-          phoneNumber || phoneNumberParam
-        );
-        setTempData(appointmentsData);
-      } catch (error) {
-        console.error("Error fetching appointments:", error);
-      } finally {
-        setLoading(false);
-      }
+      await runSearch(phoneNumber || phoneNumberParam);
     }
   };
 
@@ -179,11 +174,7 @@ export default function Search() {
           <Button
             variant="contained"
             startIcon={<SearchIcon />}
-            onClick={async () => {
-              setLoading(true);
-              setTempData(await getAppointmentsByPhoneNumber(phoneNumber));
-              setLoading(false);
-            }}
+            onClick={() => void runSearch(phoneNumber)}
             sx={{ height: 40, width: { xs: "100%", sm: "auto" }, flexShrink: 0 }}
           >
             Search
@@ -224,7 +215,7 @@ export default function Search() {
             onClose={() => setIsEditOpen(false)}
             appointment={selectedApp}
             renderEvents={async () =>
-              setTempData(await getAppointmentsByPhoneNumber(phoneNumber))
+              runSearch(phoneNumber || phoneNumberParam)
             }
             allEmployees={employees}
             allServices={services}
@@ -240,7 +231,7 @@ export default function Search() {
             onClose={() => setIsDeleteOpen(false)}
             appointment={selectedApp}
             renderEvents={async () =>
-              setTempData(await getAppointmentsByPhoneNumber(phoneNumber))
+              runSearch(phoneNumber || phoneNumberParam)
             }
             allEmployees={employees}
             orgTz={orgTz}

--- a/client/src/Login/Login.tsx
+++ b/client/src/Login/Login.tsx
@@ -14,6 +14,7 @@ import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
 import { login } from "../api/auth/auth";
 import { fetchMe } from "../api/me";
 import { meQueryKey } from "../hooks/useMe";
+import { ROUTES } from "../constants/routes";
 import { useNavigate } from "react-router-dom";
 import { AxiosError } from "axios";
 import { useState, FormEvent } from "react";
@@ -42,12 +43,12 @@ export default function Login() {
       // a salon page (or a stale previousUrl pointing at one).
       if (me.user.isPlatformAdmin) {
         localStorage.removeItem("previousUrl");
-        navigate("/Admin");
+        navigate(ROUTES.admin);
       } else if (previousUrl) {
         navigate(previousUrl);
         localStorage.removeItem("previousUrl");
       } else {
-        navigate("/");
+        navigate(ROUTES.home);
       }
     } catch (error) {
       const errors = error as AxiosError;

--- a/client/src/Navbar/MobileBottomNav.tsx
+++ b/client/src/Navbar/MobileBottomNav.tsx
@@ -13,11 +13,12 @@ import PeopleIcon from "@mui/icons-material/People";
 import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
 import MoreDrawer from "./MoreDrawer";
 import { MOBILE_BREAKPOINT } from "../constants/design";
+import { ROUTES } from "../constants/routes";
 
 const tabs = [
-  { label: "Calendar", icon: <CalendarTodayIcon />, path: "/Appointments" },
-  { label: "Search", icon: <SearchIcon />, path: "/Appointments/Search" },
-  { label: "Clients", icon: <PeopleIcon />, path: "/Clients" },
+  { label: "Calendar", icon: <CalendarTodayIcon />, path: ROUTES.appointments },
+  { label: "Search", icon: <SearchIcon />, path: ROUTES.appointmentsSearch },
+  { label: "Clients", icon: <PeopleIcon />, path: ROUTES.clients },
 ];
 
 export default function MobileBottomNav() {

--- a/client/src/Navbar/MoreDrawer.tsx
+++ b/client/src/Navbar/MoreDrawer.tsx
@@ -15,10 +15,11 @@ import LoginIcon from "@mui/icons-material/Login";
 import LogoutIcon from "@mui/icons-material/Logout";
 import { logout } from "../api/auth/auth";
 import { useMe } from "../hooks/useMe";
+import { ROUTES } from "../constants/routes";
 
 const baseItems = [
-  { title: "Employees", url: "/Employees", icon: <BadgeIcon /> },
-  { title: "Services", url: "/Services", icon: <ContentCutIcon /> },
+  { title: "Employees", url: ROUTES.employees, icon: <BadgeIcon /> },
+  { title: "Services", url: ROUTES.services, icon: <ContentCutIcon /> },
 ];
 
 export default function MoreDrawer({
@@ -35,9 +36,9 @@ export default function MoreDrawer({
   // Platform admins are org-less: only the operator console. Otherwise Settings
   // is owner-only; staff never see the entry.
   const moreItems = me?.user.isPlatformAdmin
-    ? [{ title: "Salons", url: "/Admin", icon: <StorefrontIcon /> }]
+    ? [{ title: "Salons", url: ROUTES.admin, icon: <StorefrontIcon /> }]
     : me?.user.role === "owner"
-      ? [...baseItems, { title: "Settings", url: "/Settings", icon: <SettingsIcon /> }]
+      ? [...baseItems, { title: "Settings", url: ROUTES.settings, icon: <SettingsIcon /> }]
       : baseItems;
 
   return (
@@ -83,7 +84,7 @@ export default function MoreDrawer({
             <ListItemText primary="Logout" />
           </ListItemButton>
         ) : (
-          <ListItemButton component={Link} to="/Login" onClick={onClose}>
+          <ListItemButton component={Link} to={ROUTES.login} onClick={onClose}>
             <ListItemIcon><LoginIcon /></ListItemIcon>
             <ListItemText primary="Login" />
           </ListItemButton>

--- a/client/src/Navbar/Navbar.tsx
+++ b/client/src/Navbar/Navbar.tsx
@@ -12,6 +12,7 @@ import {
 import { logout } from "../api/auth/auth";
 import { useMe } from "../hooks/useMe";
 import { MAX_CONTENT_WIDTH } from "../constants/design";
+import { ROUTES } from "../constants/routes";
 
 const navItems = [
   {
@@ -19,17 +20,17 @@ const navItems = [
     subMenu: [
       {
         title: "Search",
-        url: "/Appointments/Search",
+        url: ROUTES.appointmentsSearch,
       },
       {
         title: "Calendar",
-        url: "/Appointments",
+        url: ROUTES.appointments,
       },
     ],
   },
-  { title: "Employees", url: "/Employees" },
-  { title: "Services", url: "/Services" },
-  { title: "Clients", url: "/Clients" },
+  { title: "Employees", url: ROUTES.employees },
+  { title: "Services", url: ROUTES.services },
+  { title: "Clients", url: ROUTES.clients },
 ];
 
 
@@ -42,9 +43,9 @@ function Navbar() {
   // Platform admins are org-less: they see only the operator console, never the
   // salon nav. Otherwise Settings is owner-only; staff never see the entry.
   const items = me?.user.isPlatformAdmin
-    ? [{ title: "Salons", url: "/Admin" }]
+    ? [{ title: "Salons", url: ROUTES.admin }]
     : me?.user.role === "owner"
-      ? [...navItems, { title: "Settings", url: "/Settings" }]
+      ? [...navItems, { title: "Settings", url: ROUTES.settings }]
       : navItems;
 
   const isActive = (url: string) => location.pathname === url;
@@ -197,7 +198,7 @@ function Navbar() {
             ) : (
               <Button
                 component={Link}
-                to="/Login"
+                to={ROUTES.login}
                 variant="outlined"
                 size="small"
                 sx={{

--- a/client/src/api/api.ts
+++ b/client/src/api/api.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosRequestConfig } from "axios";
 import { refreshToken } from "./auth/auth";
+import { ROUTES } from "../constants/routes";
 const BASE_URL = import.meta.env.VITE_API_URL;
 
 declare module "axios" {
@@ -51,7 +52,7 @@ api.interceptors.response.use(
       ) {
         localStorage.removeItem("token");
         localStorage.setItem("previousUrl", window.location.pathname);
-        window.location.href = "/login";
+        window.location.href = ROUTES.login;
       } else {
         try {
           const originalRequest: AxiosRequestConfig = error.config;
@@ -64,13 +65,13 @@ api.interceptors.response.use(
           return api(originalRequest);
         } catch {
           localStorage.setItem("previousUrl", window.location.pathname);
-          window.location.href = "/login";
+          window.location.href = ROUTES.login;
         }
       }
     }
     if (status === 403) {
       localStorage.setItem("previousUrl", window.location.pathname);
-      window.location.href = "/login";
+      window.location.href = ROUTES.login;
     }
     return Promise.reject(error);
   }

--- a/client/src/api/appointments/appointments.test.ts
+++ b/client/src/api/appointments/appointments.test.ts
@@ -1,0 +1,32 @@
+import api from "../api";
+import { getAppointmentsByPhoneNumber } from "./appointments";
+
+vi.mock("../api", () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+describe("getAppointmentsByPhoneNumber", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not call the API for blank phone searches", async () => {
+    await expect(getAppointmentsByPhoneNumber("   ")).resolves.toEqual([]);
+
+    expect(api.get).not.toHaveBeenCalled();
+  });
+
+  it("encodes the searched phone number in the URL path", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce({ data: [{ id: "appt-1" }] });
+
+    await expect(getAppointmentsByPhoneNumber("330 555+1000")).resolves.toEqual([
+      { id: "appt-1" },
+    ]);
+
+    expect(api.get).toHaveBeenCalledWith(
+      "/appointments/search/330%20555%2B1000"
+    );
+  });
+});

--- a/client/src/api/appointments/appointments.ts
+++ b/client/src/api/appointments/appointments.ts
@@ -8,7 +8,14 @@ export const getAppointmentsByDate = async (date: string) => {
 };
 
 export const getAppointmentsByPhoneNumber = async (phoneNumber: string) => {
-  const response = await api.get(`/appointments/search/${phoneNumber}`);
+  const normalizedPhoneNumber = phoneNumber.trim();
+  if (!normalizedPhoneNumber) {
+    return [];
+  }
+
+  const response = await api.get(
+    `/appointments/search/${encodeURIComponent(normalizedPhoneNumber)}`
+  );
 
   return response.data;
 };

--- a/client/src/api/auth/auth.ts
+++ b/client/src/api/auth/auth.ts
@@ -1,4 +1,5 @@
 import api from "../api";
+import { ROUTES } from "../../constants/routes";
 
 export const login = async (username: string, password: string) => {
   const response = await api.post("/auth/login", {
@@ -29,5 +30,5 @@ export const logout = async () => {
     // Continue with local cleanup even if the server call fails
   }
   localStorage.removeItem("token");
-  window.location.href = "/Login";
+  window.location.href = ROUTES.login;
 };

--- a/client/src/components/RequireMe.test.tsx
+++ b/client/src/components/RequireMe.test.tsx
@@ -45,14 +45,14 @@ describe("RequireMe platform-admin gating", () => {
   it("redirects a non-admin away from an admin-only route", () => {
     asLoaded(owner);
     render(<RequireMe requirePlatformAdmin>{child()}</RequireMe>);
-    expect(screen.getByTestId("navigate")).toHaveTextContent("/Appointments");
+    expect(screen.getByTestId("navigate")).toHaveTextContent("/appointments");
     expect(screen.queryByTestId("child")).not.toBeInTheDocument();
   });
 
   it("redirects a platform admin off a salon route to the console", () => {
     asLoaded(admin);
     render(<RequireMe>{child()}</RequireMe>);
-    expect(screen.getByTestId("navigate")).toHaveTextContent("/Admin");
+    expect(screen.getByTestId("navigate")).toHaveTextContent("/admin");
   });
 
   it("renders a salon route for an owner", () => {
@@ -68,6 +68,6 @@ describe("RequireMe platform-admin gating", () => {
         {child()}
       </RequireMe>
     );
-    expect(screen.getByTestId("navigate")).toHaveTextContent("/Appointments");
+    expect(screen.getByTestId("navigate")).toHaveTextContent("/appointments");
   });
 });

--- a/client/src/components/RequireMe.tsx
+++ b/client/src/components/RequireMe.tsx
@@ -5,6 +5,7 @@ import { Navigate } from "react-router-dom";
 
 import { useMe } from "../hooks/useMe";
 import { getHttpStatus } from "../utils/httpError";
+import { ROUTES } from "../constants/routes";
 import CircularLoading from "./CircularLoading";
 
 type RequireMeProps = {
@@ -13,7 +14,7 @@ type RequireMeProps = {
   // `redirectTo`. Omitting it preserves the plain authenticated-only behavior.
   requiredRole?: string;
   // When true, the route requires a platform admin (the org-less operator). When
-  // false/omitted, platform admins are redirected to /Admin — salon pages can't
+  // false/omitted, platform admins are redirected to /admin — salon pages can't
   // function without an org, so admins are corralled into the console.
   requirePlatformAdmin?: boolean;
   redirectTo?: string;
@@ -27,7 +28,7 @@ export function RequireMe({
   children,
   requiredRole,
   requirePlatformAdmin,
-  redirectTo = "/Appointments",
+  redirectTo = ROUTES.appointments,
 }: RequireMeProps) {
   const { data, error, isError, isLoading, isPending, refetch } = useMe();
 
@@ -37,7 +38,7 @@ export function RequireMe({
 
   if (isError) {
     if (getHttpStatus(error) === 401) {
-      return <Navigate to="/Login" replace />;
+      return <Navigate to={ROUTES.login} replace />;
     }
 
     if (!data) {
@@ -60,7 +61,7 @@ export function RequireMe({
 
   // Salon route: a platform admin has no org and can't use it — send to the console.
   if (data.user.isPlatformAdmin) {
-    return <Navigate to="/Admin" replace />;
+    return <Navigate to={ROUTES.admin} replace />;
   }
 
   if (requiredRole && data.user.role !== requiredRole) {

--- a/client/src/constants/routes.ts
+++ b/client/src/constants/routes.ts
@@ -1,0 +1,27 @@
+// Centralized client-side route paths. Every <Route>, <Link to>, and navigate()
+// call should reference these so paths stay consistent and lowercase. These are
+// frontend router paths only — backend API endpoints live with their api/ modules.
+export const ROUTES = {
+  home: "/",
+  login: "/login",
+  appointments: "/appointments",
+  appointmentsSearch: "/appointments/search",
+  clients: "/clients",
+  employees: "/employees",
+  services: "/services",
+  settings: "/settings",
+  admin: "/admin",
+  adminNew: "/admin/new",
+  // Router pattern only; build a concrete path with adminOrganizationPath().
+  adminOrganization: "/admin/:organizationId",
+} as const;
+
+// Concrete path for a single organization's admin detail page.
+export const adminOrganizationPath = (organizationId: string | number) =>
+  `${ROUTES.admin}/${organizationId}`;
+
+// "All appointments for this phone number" — the search page reads the `pn` query param.
+export const appointmentsSearchPath = (phoneNumber: string | undefined) => {
+  const params = new URLSearchParams({ pn: phoneNumber ?? "" });
+  return `${ROUTES.appointmentsSearch}?${params.toString()}`;
+};

--- a/client/src/hooks/useMe.test.tsx
+++ b/client/src/hooks/useMe.test.tsx
@@ -92,7 +92,7 @@ describe("useMe", () => {
 
   it("lets the axios interceptor clear auth state on 401", async () => {
     localStorage.setItem("token", "stale-token");
-    window.history.pushState({}, "", "/Appointments");
+    window.history.pushState({}, "", "/appointments");
 
     await expect(
       responseInterceptor().rejected({
@@ -105,12 +105,12 @@ describe("useMe", () => {
     ).rejects.toBeDefined();
 
     expect(localStorage.getItem("token")).toBeNull();
-    expect(localStorage.getItem("previousUrl")).toBe("/Appointments");
+    expect(localStorage.getItem("previousUrl")).toBe("/appointments");
   });
 
   it("does not trigger the logout interceptor on 503", async () => {
     localStorage.setItem("token", "still-valid");
-    window.history.pushState({}, "", "/Appointments");
+    window.history.pushState({}, "", "/appointments");
 
     const unavailable = {
       response: {
@@ -164,17 +164,17 @@ describe("RequireMe", () => {
 
   function renderProtected() {
     return render(
-      <MemoryRouter initialEntries={["/Appointments"]}>
+      <MemoryRouter initialEntries={["/appointments"]}>
         <Routes>
           <Route
-            path="/Appointments"
+            path="/appointments"
             element={
               <RequireMe>
                 <div>Protected content</div>
               </RequireMe>
             }
           />
-          <Route path="/Login" element={<div>Login screen</div>} />
+          <Route path="/login" element={<div>Login screen</div>} />
         </Routes>
       </MemoryRouter>
     );
@@ -225,17 +225,17 @@ describe("RequireMe", () => {
 
   function renderRoleProtected() {
     return render(
-      <MemoryRouter initialEntries={["/Settings"]}>
+      <MemoryRouter initialEntries={["/settings"]}>
         <Routes>
           <Route
-            path="/Settings"
+            path="/settings"
             element={
               <RequireMe requiredRole="owner">
                 <div>Owner only</div>
               </RequireMe>
             }
           />
-          <Route path="/Appointments" element={<div>Appointments screen</div>} />
+          <Route path="/appointments" element={<div>Appointments screen</div>} />
         </Routes>
       </MemoryRouter>
     );


### PR DESCRIPTION
Summary:
- Centralize frontend route paths with lowercase URLs.
- Prevent blank appointment phone searches from calling /appointments/search.
- Add Vitest coverage for the appointment search API wrapper.

Tests:
- npm test
- npx tsc -b --noEmit
- npm run lint (passes with existing fast-refresh warnings in AdminPage/Organizations.tsx and SettingsPage/Settings.tsx)