### PR TITLE
Sync appointment date fields

### DIFF
--- a/client/src/AppointmentsPage/components/AppointmentModal.tsx
+++ b/client/src/AppointmentsPage/components/AppointmentModal.tsx
@@ -35,6 +35,11 @@ import {
   nowInSalon,
   toIsoFromSalonInput,
 } from "../../utils/datetime";
+import {
+  appointmentWithEndChange,
+  appointmentWithStartChange,
+  startForEndChangeValidation,
+} from "./appointmentDateSync";
 
 export default function AppointmentModal({
   orgTz,
@@ -94,32 +99,40 @@ export default function AppointmentModal({
 
   const updateStart = (date: dayjs.Dayjs | null) => {
     if (!date) return;
-    setForm({
-      ...form,
-      startsAt: toIsoFromSalonInput(
-        date.format("YYYY-MM-DD"),
-        date.format("HH:mm:ss"),
-        orgTz
-      ),
-    });
+    setForm(
+      appointmentWithStartChange({
+        form,
+        nextStart: date,
+        currentStart: startValue,
+        currentEnd: endValue,
+        orgTz,
+      })
+    );
   };
 
   const updateEnd = (date: dayjs.Dayjs | null) => {
     if (!date) return;
     const nextEnd = date;
-    if (nextEnd.isSame(startValue) || nextEnd.isBefore(startValue)) {
+    const nextStart = startForEndChangeValidation({
+      nextEnd,
+      currentStart: startValue,
+      currentEnd: endValue,
+    });
+
+    if (nextEnd.isSame(nextStart) || nextEnd.isBefore(nextStart)) {
       setEndTimeCustomError("End time must be after start time");
     } else {
       setEndTimeCustomError("");
     }
-    setForm({
-      ...form,
-      endsAt: toIsoFromSalonInput(
-        nextEnd.format("YYYY-MM-DD"),
-        nextEnd.format("HH:mm:ss"),
-        orgTz
-      ),
-    });
+    setForm(
+      appointmentWithEndChange({
+        form,
+        nextEnd,
+        currentStart: startValue,
+        currentEnd: endValue,
+        orgTz,
+      })
+    );
   };
 
   const errorMessage = useCallback((error: DateTimeValidationError | null) => {

--- a/client/src/AppointmentsPage/components/appointmentDateSync.test.ts
+++ b/client/src/AppointmentsPage/components/appointmentDateSync.test.ts
@@ -1,0 +1,77 @@
+import { type Appointment } from "../../types";
+import { dateTimeInSalon } from "../../utils/datetime";
+import {
+  appointmentWithEndChange,
+  appointmentWithStartChange,
+  startForEndChangeValidation,
+} from "./appointmentDateSync";
+
+const orgTz = "America/New_York";
+
+const baseAppointment: Appointment = {
+  id: "44444444-4444-4444-8444-444444444444",
+  employeeId: "11111111-1111-4111-8111-111111111111",
+  startsAt: "2026-05-26T13:30:00Z",
+  endsAt: "2026-05-26T14:30:00Z",
+  name: "Mina",
+  phoneNumber: "555-0100",
+  services: ["22222222-2222-4222-8222-222222222222"],
+  reminderSent: false,
+  showedUp: false,
+};
+
+function salonDateTime(iso: string) {
+  return dateTimeInSalon(iso, orgTz).format("YYYY-MM-DD HH:mm:ss");
+}
+
+describe("appointment date sync", () => {
+  it("matches the end date to a changed start date while preserving both times", () => {
+    const currentStart = dateTimeInSalon(baseAppointment.startsAt, orgTz);
+    const currentEnd = dateTimeInSalon(baseAppointment.endsAt, orgTz);
+    const nextStart = currentStart.add(2, "day");
+
+    const updated = appointmentWithStartChange({
+      form: baseAppointment,
+      nextStart,
+      currentStart,
+      currentEnd,
+      orgTz,
+    });
+
+    expect(salonDateTime(updated.startsAt)).toBe("2026-05-28 09:30:00");
+    expect(salonDateTime(updated.endsAt)).toBe("2026-05-28 10:30:00");
+  });
+
+  it("matches the start date to a changed end date while preserving both times", () => {
+    const currentStart = dateTimeInSalon(baseAppointment.startsAt, orgTz);
+    const currentEnd = dateTimeInSalon(baseAppointment.endsAt, orgTz);
+    const nextEnd = currentEnd.add(3, "day");
+
+    const updated = appointmentWithEndChange({
+      form: baseAppointment,
+      nextEnd,
+      currentStart,
+      currentEnd,
+      orgTz,
+    });
+
+    expect(salonDateTime(updated.startsAt)).toBe("2026-05-29 09:30:00");
+    expect(salonDateTime(updated.endsAt)).toBe("2026-05-29 10:30:00");
+  });
+
+  it("validates changed end dates against the matched start date", () => {
+    const currentStart = dateTimeInSalon(baseAppointment.startsAt, orgTz);
+    const currentEnd = dateTimeInSalon(baseAppointment.endsAt, orgTz);
+    const nextEnd = currentEnd.add(1, "day");
+
+    const validationStart = startForEndChangeValidation({
+      nextEnd,
+      currentStart,
+      currentEnd,
+    });
+
+    expect(validationStart.format("YYYY-MM-DD HH:mm:ss")).toBe(
+      "2026-05-27 09:30:00"
+    );
+  });
+});

--- a/client/src/AppointmentsPage/components/appointmentDateSync.ts
+++ b/client/src/AppointmentsPage/components/appointmentDateSync.ts
@@ -1,0 +1,74 @@
+import { type Dayjs } from "dayjs";
+
+import { type Appointment } from "../../types";
+import { toIsoFromSalonInput } from "../../utils/datetime";
+
+export function appointmentWithStartChange({
+  form,
+  nextStart,
+  currentStart,
+  currentEnd,
+  orgTz,
+}: {
+  form: Appointment;
+  nextStart: Dayjs;
+  currentStart: Dayjs;
+  currentEnd: Dayjs;
+  orgTz: string;
+}): Appointment {
+  const nextDate = nextStart.format("YYYY-MM-DD");
+  const startDateChanged = !nextStart.isSame(currentStart, "day");
+
+  return {
+    ...form,
+    startsAt: toIsoFromSalonInput(nextDate, nextStart.format("HH:mm:ss"), orgTz),
+    endsAt: startDateChanged
+      ? toIsoFromSalonInput(nextDate, currentEnd.format("HH:mm:ss"), orgTz)
+      : form.endsAt,
+  };
+}
+
+export function startForEndChangeValidation({
+  nextEnd,
+  currentStart,
+  currentEnd,
+}: {
+  nextEnd: Dayjs;
+  currentStart: Dayjs;
+  currentEnd: Dayjs;
+}): Dayjs {
+  if (nextEnd.isSame(currentEnd, "day")) {
+    return currentStart;
+  }
+
+  return nextEnd
+    .hour(currentStart.hour())
+    .minute(currentStart.minute())
+    .second(currentStart.second())
+    .millisecond(currentStart.millisecond());
+}
+
+export function appointmentWithEndChange({
+  form,
+  nextEnd,
+  currentStart,
+  currentEnd,
+  orgTz,
+}: {
+  form: Appointment;
+  nextEnd: Dayjs;
+  currentStart: Dayjs;
+  currentEnd: Dayjs;
+  orgTz: string;
+}): Appointment {
+  const nextDate = nextEnd.format("YYYY-MM-DD");
+  const endDateChanged = !nextEnd.isSame(currentEnd, "day");
+
+  return {
+    ...form,
+    startsAt: endDateChanged
+      ? toIsoFromSalonInput(nextDate, currentStart.format("HH:mm:ss"), orgTz)
+      : form.startsAt,
+    endsAt: toIsoFromSalonInput(nextDate, nextEnd.format("HH:mm:ss"), orgTz),
+  };
+}


### PR DESCRIPTION
## Summary
- sync the end date when the start date changes in the appointment editor
- sync the start date when the end date changes while preserving each side's time
- add focused regression tests for both date-sync directions

## Tests
- cd client && npm test -- AppointmentModal.test.tsx appointmentDateSync.test.ts
- cd client && npm test
- cd client && npx tsc -b --noEmit
- cd client && npm run lint